### PR TITLE
Make subscribe accept and return CancelToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,22 +124,22 @@ Events can be received in three different fashions. All APIs are non-blocking.
 
 **Subscribe API**
 
-`def subscribe(self, event_type: Type[BaseEvent], handler: Callable[[BaseEvent], None]) -> Subscription:`
+`def subscribe(self, event_type: Type[BaseEvent], handler: Callable[[BaseEvent], None]) -> CancelToken:`
 
 *Example:*
 
 ```Python
-subscription = endpoint.subscribe(SecondThingHappened, lambda event: 
+cancel_token = endpoint.subscribe(SecondThingHappened, lambda event: 
     print("Received via SUBSCRIBE API in proc1: ", event.payload)
 )
 ```
 
-The handler will be called every time that a `SecondThingHappened` event is fired. Notice that the returned `Subscription` allows deregistering from the event at any later point in time.
+The handler will be called every time that a `SecondThingHappened` event is fired. Notice that the returned `CancelToken` allows deregistering from the event at any later point in time.
 
 *Example:*
 
 ```Python
-subscription.unsubscribe()
+cancel_token.trigger()
 ```
 
 **Stream API**

--- a/examples/request_api.py
+++ b/examples/request_api.py
@@ -6,17 +6,24 @@ from lahja import (
     Endpoint,
     EventBus,
     BaseEvent,
+    BaseRequestResponseEvent,
     BroadcastConfig,
 )
 
-# Define request / response pair
-class GetSomethingRequest(BaseEvent):
-    pass
 
 class DeliverSomethingResponse(BaseEvent):
     def __init__(self, payload):
         super().__init__()
         self.payload = payload
+
+
+# Define request / response pair
+class GetSomethingRequest(BaseRequestResponseEvent[DeliverSomethingResponse]):
+
+    @staticmethod
+    def expected_response_type():
+        return DeliverSomethingResponse
+
 
 # Base functions for first process
 def run_proc1(endpoint):

--- a/lahja/__init__.py
+++ b/lahja/__init__.py
@@ -11,5 +11,4 @@ from .misc import (  # noqa: F401
     BaseEvent,
     BaseRequestResponseEvent,
     BroadcastConfig,
-    Subscription,
 )

--- a/lahja/endpoint.py
+++ b/lahja/endpoint.py
@@ -195,18 +195,6 @@ class Endpoint:
 
         return token
 
-    async def _run_when_triggered(self, token: CancelToken, handler: Callable[..., Any]) -> None:
-        await token.wait()
-        handler()
-
-    def _chain_or_create_cancel_token(self,
-                                      token_name: str,
-                                      token: Optional[CancelToken] = None) -> CancelToken:
-
-        return (CancelToken(token_name, self.loop).chain(token)
-                if token is not None else
-                CancelToken(token_name, self.loop))
-
     TStreamEvent = TypeVar('TStreamEvent', bound=BaseEvent)
 
     async def stream(self,
@@ -266,3 +254,15 @@ class Endpoint:
     def _raise_if_loop_missing(self) -> None:
         if self._loop is None:
             raise NoConnection("Need to call `connect()` first")
+
+    async def _run_when_triggered(self, token: CancelToken, handler: Callable[..., Any]) -> None:
+        await token.wait()
+        handler()
+
+    def _chain_or_create_cancel_token(self,
+                                      token_name: str,
+                                      token: Optional[CancelToken] = None) -> CancelToken:
+
+        return (CancelToken(token_name, self.loop).chain(token)
+                if token is not None else
+                CancelToken(token_name, self.loop))

--- a/lahja/endpoint.py
+++ b/lahja/endpoint.py
@@ -142,7 +142,8 @@ class Endpoint:
                       cancel_token: Optional[CancelToken] = None) -> TResponse:
         """
         Broadcast an instance of :class:`~lahja.misc.BaseEvent` on the event bus and immediately
-        wait on an expected answer of type :class:`~lahja.misc.BaseEvent`.
+        wait on an expected answer of type :class:`~lahja.misc.BaseEvent`. Optionally pass an
+        :class:`~cancel_token.CancelToken` to cancel the request.
         """
         item._origin = self.name
         item._id = str(uuid.uuid4())
@@ -176,8 +177,9 @@ class Endpoint:
                   cancel_token: Optional[CancelToken] = None) -> CancelToken:
         """
         Subscribe to receive updates for any event that matches the specified event type.
-        A handler is passed as a second argument an :class:`~lahja.misc.Subscription` is returned
-        to unsubscribe from the event if needed.
+        A handler is passed as a second argument. A :class:`~cancel_token.CancelToken` is
+        returned to unsubscribe. Optionally a :class:`~cancel_token.CancelToken` can also
+        be passed unsubscribe whenever the token is triggered.
         """
         if event_type not in self._handler:
             self._handler[event_type] = []
@@ -206,6 +208,8 @@ class Endpoint:
         ``AsyncIterable[BaseEvent]`` which can be consumed through an ``async for`` loop.
         An optional ``max`` parameter can be passed to stop streaming after a maximum amount
         of events was received.
+        Optionally a :class:`~cancel_token.CancelToken` can be passed to unsubscribe from the
+        stream. Additionally it is possible to break out of the loop at any time.
         """
         queue: asyncio.Queue = asyncio.Queue()
 
@@ -241,6 +245,8 @@ class Endpoint:
                        cancel_token: Optional[CancelToken] = None) -> TWaitForEvent:
         """
         Wait for a single instance of an event that matches the specified event type.
+        Optionally a :class:`~cancel_token.CancelToken` can be passed to unsubscribe from the
+        event.
         """
 
         token = self._chain_or_create_cancel_token(f'wait_for#{event_type}', cancel_token)

--- a/lahja/endpoint.py
+++ b/lahja/endpoint.py
@@ -233,7 +233,7 @@ class Endpoint:
             try:
                 yield event
             except GeneratorExit:
-                self._queues[event_type].remove(queue)
+                token.trigger()
             else:
                 if i is not None and i >= cast(int, max):
                     token.trigger()

--- a/lahja/eventbus.py
+++ b/lahja/eventbus.py
@@ -69,7 +69,8 @@ class EventBus:
                 if not self._is_allowed_to_receive(config, endpoint.name):
                     continue
 
-                endpoint._receiving_queue.put_nowait((item, config))
+                if self._running:
+                    endpoint._receiving_queue.put_nowait((item, config))
 
     def _is_allowed_to_receive(self, config: BroadcastConfig, endpoint: str) -> bool:
         return config is None or config.allowed_to_receive(endpoint)

--- a/lahja/exceptions.py
+++ b/lahja/exceptions.py
@@ -10,3 +10,10 @@ class UnexpectedResponse(LahjaError):
     Raised when the type of a response did not match the ``expected_response_type``.
     """
     pass
+
+
+class NoConnection(LahjaError):
+    """
+    Raised when an API call was made prior to connecting the ``Endpoint```
+    """
+    pass

--- a/lahja/misc.py
+++ b/lahja/misc.py
@@ -12,15 +12,6 @@ from typing import (  # noqa: F401
 )
 
 
-class Subscription:
-
-    def __init__(self, unsubscribe_fn: Callable[[], Any]) -> None:
-        self._unsubscribe_fn = unsubscribe_fn
-
-    def unsubscribe(self) -> None:
-        self._unsubscribe_fn()
-
-
 class BroadcastConfig:
 
     def __init__(self,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,10 @@ from setuptools import (
     find_packages,
 )
 
-extras_require = {
+deps = {
+    'lahja': [
+        "asyncio-cancel-token==0.1.0a2",
+    ],
     'test': [
         "pytest==3.3.2",
         "pytest-asyncio==0.8.0",
@@ -30,12 +33,15 @@ extras_require = {
     ],
 }
 
-extras_require['dev'] = (
-    extras_require['dev'] +
-    extras_require['test'] +
-    extras_require['lint'] +
-    extras_require['doc']
+deps['dev'] = (
+    deps['lahja'] +
+    deps['dev'] +
+    deps['test'] +
+    deps['lint'] +
+    deps['doc']
 )
+
+install_requires = deps['lahja']
 
 setup(
     name='lahja',
@@ -47,10 +53,10 @@ setup(
     author_email='christoph.burgdorf@gmail.com',
     url='https://github.com/ethereum/lahja',
     include_package_data=True,
-    install_requires=[],
+    install_requires=install_requires,
     setup_requires=['setuptools-markdown'],
     python_requires='>=3.5, <4',
-    extras_require=extras_require,
+    extras_require=deps,
     py_modules=['lahja'],
     license="MIT",
     zip_safe=False,

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,0 +1,33 @@
+import asyncio
+from typing import (
+    Generator,
+)
+
+import pytest
+
+from lahja import (
+    Endpoint,
+    EventBus,
+)
+
+
+@pytest.fixture(scope='session')
+def event_loop() -> Generator[asyncio.AbstractEventLoop, None, None]:
+    loop = asyncio.new_event_loop()
+    try:
+        yield loop
+    finally:
+        loop.close()
+
+
+@pytest.fixture(scope='module')
+def endpoint(event_loop: asyncio.AbstractEventLoop) -> Generator[Endpoint, None, None]:
+    bus = EventBus()
+    endpoint = bus.create_endpoint('test')
+    bus.start(event_loop)
+    endpoint.connect(event_loop)
+    try:
+        yield endpoint
+    finally:
+        endpoint.stop()
+        bus.stop()


### PR DESCRIPTION
## What was wrong?

As described in #9 we need to add native support for `CancelToken`

## How was it fixed?

Added first class `CancelToken` support for all APIs

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
