### PR TITLE
Some minor fixes and cleanup

### DIFF
--- a/examples/request_api.py
+++ b/examples/request_api.py
@@ -6,17 +6,24 @@ from lahja import (
     Endpoint,
     EventBus,
     BaseEvent,
+    BaseRequestResponseEvent,
     BroadcastConfig,
 )
 
-# Define request / response pair
-class GetSomethingRequest(BaseEvent):
-    pass
 
 class DeliverSomethingResponse(BaseEvent):
     def __init__(self, payload):
         super().__init__()
         self.payload = payload
+
+
+# Define request / response pair
+class GetSomethingRequest(BaseRequestResponseEvent[DeliverSomethingResponse]):
+
+    @staticmethod
+    def expected_response_type():
+        return DeliverSomethingResponse
+
 
 # Base functions for first process
 def run_proc1(endpoint):

--- a/lahja/endpoint.py
+++ b/lahja/endpoint.py
@@ -180,7 +180,6 @@ class Endpoint:
             self._queues[event_type] = []
 
         self._queues[event_type].append(queue)
-
         i = None if max is None else 0
         while True:
             event = await queue.get()
@@ -192,6 +191,7 @@ class Endpoint:
                 self._queues[event_type].remove(queue)
             else:
                 if i is not None and i >= cast(int, max):
+                    self._queues[event_type].remove(queue)
                     break
 
     TWaitForEvent = TypeVar('TWaitForEvent', bound=BaseEvent)

--- a/lahja/eventbus.py
+++ b/lahja/eventbus.py
@@ -69,7 +69,8 @@ class EventBus:
                 if not self._is_allowed_to_receive(config, endpoint.name):
                     continue
 
-                endpoint._receiving_queue.put_nowait((item, config))
+                if self._running:
+                    endpoint._receiving_queue.put_nowait((item, config))
 
     def _is_allowed_to_receive(self, config: BroadcastConfig, endpoint: str) -> bool:
         return config is None or config.allowed_to_receive(endpoint)

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,0 +1,24 @@
+import asyncio
+from typing import (
+    Generator,
+)
+
+import pytest
+
+from lahja import (
+    Endpoint,
+    EventBus,
+)
+
+
+@pytest.fixture(scope='function')
+def endpoint(event_loop: asyncio.AbstractEventLoop) -> Generator[Endpoint, None, None]:
+    bus = EventBus()
+    endpoint = bus.create_endpoint('test')
+    bus.start(event_loop)
+    endpoint.connect(event_loop)
+    try:
+        yield endpoint
+    finally:
+        endpoint.stop()
+        bus.stop()

--- a/tests/core/test_basics.py
+++ b/tests/core/test_basics.py
@@ -9,6 +9,7 @@ import pytest
 from lahja import (
     BaseEvent,
     BaseRequestResponseEvent,
+    Endpoint,
     EventBus,
     UnexpectedResponse,
 )
@@ -34,12 +35,7 @@ class DummyRequestPair(BaseRequestResponseEvent[DummyResponse]):
 
 
 @pytest.mark.asyncio
-async def test_request() -> None:
-    bus = EventBus()
-    endpoint = bus.create_endpoint('test')
-    bus.start()
-    endpoint.connect()
-
+async def test_request(endpoint: Endpoint) -> None:
     endpoint.subscribe(
         DummyRequestPair,
         lambda ev: endpoint.broadcast(
@@ -54,12 +50,10 @@ async def test_request() -> None:
     # mypy has the type information we think it has. We run mypy on the tests.
     print(response.property_of_dummy_response)
     assert isinstance(response, DummyResponse)
-    endpoint.stop()
-    bus.stop()
 
 
 @pytest.mark.asyncio
-async def test_response_must_match() -> None:
+async def test_response_must_match(endpoint: Endpoint) -> None:
     bus = EventBus()
     endpoint = bus.create_endpoint('test')
     bus.start()
@@ -81,11 +75,7 @@ async def test_response_must_match() -> None:
 
 
 @pytest.mark.asyncio
-async def test_stream_with_max() -> None:
-    bus = EventBus()
-    endpoint = bus.create_endpoint('test')
-    bus.start()
-    endpoint.connect()
+async def test_stream_with_max(endpoint: Endpoint) -> None:
     stream_counter = 0
 
     async def stream_response() -> None:
@@ -103,17 +93,11 @@ async def test_stream_with_max() -> None:
         endpoint.broadcast(DummyRequest())
 
     await asyncio.sleep(0.01)
-    endpoint.stop()
-    bus.stop()
     assert stream_counter == 2
 
 
 @pytest.mark.asyncio
-async def test_wait_for() -> None:
-    bus = EventBus()
-    endpoint = bus.create_endpoint('test')
-    bus.start()
-    endpoint.connect()
+async def test_wait_for(endpoint: Endpoint) -> None:
     received = None
 
     async def stream_response() -> None:
@@ -128,6 +112,4 @@ async def test_wait_for() -> None:
     endpoint.broadcast(DummyRequest())
 
     await asyncio.sleep(0.01)
-    endpoint.stop()
-    bus.stop()
     assert isinstance(received, DummyRequest)

--- a/tests/core/test_basics.py
+++ b/tests/core/test_basics.py
@@ -45,11 +45,14 @@ async def test_request(endpoint: Endpoint) -> None:
         )
     )
 
-    response = await endpoint.request(DummyRequestPair())
+    item = DummyRequestPair()
+    response = await endpoint.request(item)
     # Accessing `ev.property_of_dummy_response` here allows us to validate
     # mypy has the type information we think it has. We run mypy on the tests.
     print(response.property_of_dummy_response)
     assert isinstance(response, DummyResponse)
+    # Ensure the registration was cleaned up
+    assert item._id not in endpoint._futures
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What was wrong?

Since it seems we won't add `CancelToken` support as proposed in #9, here are a couple of things that I extracted from that PR:

- A fix were we tried to propagate events when the event bus was already shut down
- fixed broken example
- tightened tests and assertions
- basic cleanup

## How was it fixed?

:fire: 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
