### PR TITLE
Ensure cancelled `request` does not leave stale registration behind

### DIFF
--- a/tests/core/test_basics.py
+++ b/tests/core/test_basics.py
@@ -56,6 +56,17 @@ async def test_request(endpoint: Endpoint) -> None:
 
 
 @pytest.mark.asyncio
+async def test_request_can_get_cancelled(endpoint: Endpoint) -> None:
+
+    item = DummyRequestPair()
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(endpoint.request(item), 0.1)
+    await asyncio.sleep(0.01)
+    # Ensure the registration was cleaned up
+    assert item._id not in endpoint._futures
+
+
+@pytest.mark.asyncio
 async def test_response_must_match(endpoint: Endpoint) -> None:
     bus = EventBus()
     endpoint = bus.create_endpoint('test')


### PR DESCRIPTION
## What was wrong?

Currently if the consumption of `bus.request(Something()` is cancelled, we are leaving a stale registration behind.

## How was it fixed?

Detect cancelled Future and remove registration.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
