### PR TITLE
Implement internal events

### DIFF
--- a/lahja/endpoint.py
+++ b/lahja/endpoint.py
@@ -128,7 +128,12 @@ class Endpoint:
         all connected endpoints with their consuming call sites.
         """
         item._origin = self.name
-        self._sending_queue.put_nowait((item, config))
+        if config is not None and config.internal:
+            # Internal events simply bypass going through the central event bus
+            # and are directly put into the local receiving queue instead.
+            self._receiving_queue.put_nowait((item, config))
+        else:
+            self._sending_queue.put_nowait((item, config))
 
     TResponse = TypeVar('TResponse', bound=BaseEvent)
 

--- a/lahja/misc.py
+++ b/lahja/misc.py
@@ -25,10 +25,15 @@ class BroadcastConfig:
 
     def __init__(self,
                  filter_endpoint: Optional[str] = None,
-                 filter_event_id: Optional[str] = None) -> None:
+                 filter_event_id: Optional[str] = None,
+                 internal: bool = False) -> None:
 
         self.filter_endpoint = filter_endpoint
         self.filter_event_id = filter_event_id
+        self.internal = internal
+
+        if self.internal and self.filter_endpoint is not None:
+            raise ValueError("`internal` can not be used with `filter_endpoint")
 
     def allowed_to_receive(self, endpoint: str) -> bool:
         return self.filter_endpoint is None or self.filter_endpoint == endpoint
@@ -40,7 +45,13 @@ class BaseEvent:
     _id: Optional[str] = None
     _config: Optional[BroadcastConfig] = None
 
-    def broadcast_config(self) -> BroadcastConfig:
+    def broadcast_config(self, internal: bool = False) -> BroadcastConfig:
+        if internal:
+            return BroadcastConfig(
+                internal=True,
+                filter_event_id=self._id
+            )
+
         return BroadcastConfig(
             filter_endpoint=self._origin,
             filter_event_id=self._id

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,6 +1,7 @@
 import asyncio
 from typing import (
     Generator,
+    Tuple,
 )
 
 import pytest
@@ -21,4 +22,22 @@ def endpoint(event_loop: asyncio.AbstractEventLoop) -> Generator[Endpoint, None,
         yield endpoint
     finally:
         endpoint.stop()
+        bus.stop()
+
+
+@pytest.fixture(scope='function')
+def pair_of_endpoints(event_loop: asyncio.AbstractEventLoop
+                      ) -> Generator[Tuple[Endpoint, Endpoint], None, None]:
+
+    bus = EventBus()
+    endpoint1 = bus.create_endpoint('e1')
+    endpoint2 = bus.create_endpoint('e2')
+    bus.start(event_loop)
+    endpoint1.connect(event_loop)
+    endpoint2.connect(event_loop)
+    try:
+        yield endpoint1, endpoint2
+    finally:
+        endpoint1.stop()
+        endpoint2.stop()
         bus.stop()

--- a/tests/core/test_internal.py
+++ b/tests/core/test_internal.py
@@ -1,0 +1,50 @@
+import asyncio
+from typing import (
+    Any,
+    Tuple,
+)
+
+import pytest
+
+from lahja import (
+    BaseEvent,
+    BroadcastConfig,
+    Endpoint,
+)
+
+
+class DummyResponse(BaseEvent):
+    property_of_dummy_response = None
+
+    def __init__(self, something: Any) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_internal_propagation(pair_of_endpoints: Tuple[Endpoint, Endpoint]) -> None:
+
+    endpoint1, endpoint2 = pair_of_endpoints
+
+    async def broadcast_dummies() -> None:
+        while True:
+            # We are broadcasting internally on endpoint1
+            endpoint1.broadcast(
+                DummyResponse("Dummy"),
+                BroadcastConfig(internal=True)
+            )
+            await asyncio.sleep(0.01)
+
+    asyncio.ensure_future(broadcast_dummies())
+
+    e1_task = asyncio.ensure_future(endpoint1.wait_for(DummyResponse))
+    # We expect that this will never receive an answer
+    e2_task = asyncio.ensure_future(endpoint2.wait_for(DummyResponse))
+
+    done, pending = await asyncio.wait(
+        {e1_task, e2_task},
+        timeout=0.05
+    )
+    assert e1_task in done
+    assert e2_task not in done
+    assert e2_task in pending
+    assert e1_task not in pending


### PR DESCRIPTION
## What was wrong?

As described in #10. Currently the event bus always propagates every event at least one process hop to the process that holds the central `EventBus` to then decide whether to pass it on to a specific `Endpoint` or not.

Not only is this a waste of resources for events that do not need to propagate outside of the current `Endpoint` it will also prevent us from propagating non-pickable events in such cases.

## How was it fixed?

Added `internal` to the `BroadcastConfig` and then decide based on that to either propagate externally or just internally.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
