### PR TITLE
Ensure internal events work with non-pickable events

### DIFF
--- a/examples/inter_process_ping_pong.py
+++ b/examples/inter_process_ping_pong.py
@@ -25,7 +25,7 @@ class SecondThingHappened(BaseExampleEvent):
 # Base functions for first process
 def run_proc1(endpoint):
     loop = asyncio.get_event_loop()
-    endpoint.connect()
+    endpoint.connect_no_wait()
     endpoint.subscribe(SecondThingHappened, lambda event: 
         print("Received via SUBSCRIBE API in proc1: ", event.payload)
     )
@@ -47,7 +47,7 @@ async def proc1_worker(endpoint):
 # Base functions for second process
 def run_proc2(endpoint):
     loop = asyncio.get_event_loop()
-    endpoint.connect()
+    endpoint.connect_no_wait()
     endpoint.subscribe(FirstThingHappened, lambda event: 
         print("Received via SUBSCRIBE API in proc2:", event.payload)
     )

--- a/examples/request_api.py
+++ b/examples/request_api.py
@@ -28,7 +28,7 @@ class GetSomethingRequest(BaseRequestResponseEvent[DeliverSomethingResponse]):
 # Base functions for first process
 def run_proc1(endpoint):
     loop = asyncio.get_event_loop()
-    endpoint.connect()
+    endpoint.connect_no_wait()
     # Listen for `GetSomethingRequest`'s
     endpoint.subscribe(GetSomethingRequest, lambda event:
         # Send a response back to *only* who made that request
@@ -39,7 +39,7 @@ def run_proc1(endpoint):
 # Base functions for second process
 def run_proc2(endpoint):
     loop = asyncio.get_event_loop()
-    endpoint.connect()
+    endpoint.connect_no_wait()
 
     loop.run_until_complete(proc2_worker(endpoint))
 

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,6 +1,6 @@
 import asyncio
 from typing import (
-    Generator,
+    AsyncGenerator,
     Tuple,
 )
 
@@ -13,11 +13,11 @@ from lahja import (
 
 
 @pytest.fixture(scope='function')
-def endpoint(event_loop: asyncio.AbstractEventLoop) -> Generator[Endpoint, None, None]:
+async def endpoint(event_loop: asyncio.AbstractEventLoop) -> AsyncGenerator[Endpoint, None]:
     bus = EventBus()
     endpoint = bus.create_endpoint('test')
     bus.start(event_loop)
-    endpoint.connect(event_loop)
+    await endpoint.connect(event_loop)
     try:
         yield endpoint
     finally:
@@ -26,15 +26,15 @@ def endpoint(event_loop: asyncio.AbstractEventLoop) -> Generator[Endpoint, None,
 
 
 @pytest.fixture(scope='function')
-def pair_of_endpoints(event_loop: asyncio.AbstractEventLoop
-                      ) -> Generator[Tuple[Endpoint, Endpoint], None, None]:
+async def pair_of_endpoints(event_loop: asyncio.AbstractEventLoop
+                            ) -> AsyncGenerator[Tuple[Endpoint, Endpoint], None]:
 
     bus = EventBus()
     endpoint1 = bus.create_endpoint('e1')
     endpoint2 = bus.create_endpoint('e2')
     bus.start(event_loop)
-    endpoint1.connect(event_loop)
-    endpoint2.connect(event_loop)
+    await endpoint1.connect(event_loop)
+    await endpoint2.connect(event_loop)
     try:
         yield endpoint1, endpoint2
     finally:

--- a/tests/core/test_basics.py
+++ b/tests/core/test_basics.py
@@ -10,7 +10,6 @@ from lahja import (
     BaseEvent,
     BaseRequestResponseEvent,
     Endpoint,
-    EventBus,
     UnexpectedResponse,
 )
 
@@ -68,11 +67,6 @@ async def test_request_can_get_cancelled(endpoint: Endpoint) -> None:
 
 @pytest.mark.asyncio
 async def test_response_must_match(endpoint: Endpoint) -> None:
-    bus = EventBus()
-    endpoint = bus.create_endpoint('test')
-    bus.start()
-    await endpoint.connect()
-
     endpoint.subscribe(
         DummyRequestPair,
         lambda ev: endpoint.broadcast(
@@ -84,8 +78,6 @@ async def test_response_must_match(endpoint: Endpoint) -> None:
 
     with pytest.raises(UnexpectedResponse):
         await endpoint.request(DummyRequestPair())
-    endpoint.stop()
-    bus.stop()
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_basics.py
+++ b/tests/core/test_basics.py
@@ -71,7 +71,7 @@ async def test_response_must_match(endpoint: Endpoint) -> None:
     bus = EventBus()
     endpoint = bus.create_endpoint('test')
     bus.start()
-    endpoint.connect()
+    await endpoint.connect()
 
     endpoint.subscribe(
         DummyRequestPair,


### PR DESCRIPTION
## What was wrong?

As described in #17 internal events do not work with non-pickable events as is (but should)

## How was it fixed?

First off, apologies that this turned into some re-architecture that is now mangled in a single commit and hard to detangle. As I was fixing the core problem - which is that internal events need to be propagate through their own special purpose queue - I stumbled over a bunch of problems that needed to be addressed. 

So here is what this does in a nutshell:

- use an `asyncio.Queue` to propagate internal events
- simplify the `def connect()` logic and rename to `def connect_no_wait()`
- add an `async def wait_for_connection()` API that allows async waiting up to the point where the background processing loops have started their work. This fixing an important problem that existed to far which was that one could accidentally `broadcast` before the internal things where actually ready, resulting in run time errors.
- add a new `async def connect()` API that just calls `connect_no_wait` and then does `await self.wait_for_connection`
- ensure `Optional[T]` is handled consistently via non-optional properties that raise a `NoConnection()` error in case `T` happens to be `None`
- turn the `endpoint` / `pair_of_endpoints` fixtures into `async` fixtures ensuring that they do not yield before the endpoints are connected
- migrate a test that previously could not use the `Endpoint` fixture (maybe related to the previous point) to use the fixture.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i2-prod.mirror.co.uk/incoming/article8924649.ece/ALTERNATES/s615/PAY-This-is-the-stunning-moment-a-majestic-stag-appears-to-breathe-fire.jpg)
