### PR TITLE
Christoph/feat/request with broadcast config

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ from setuptools import (
 
 extras_require = {
     'test': [
+        "cytoolz>=0.9.0,<1.0.0",
         "pytest==3.3.2",
         "pytest-asyncio==0.8.0",
         "pytest-xdist",

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -11,6 +11,9 @@ from lahja import (
     EventBus,
 )
 
+EndpointPair = Tuple[Endpoint, Endpoint]
+EndpointTriplet = Tuple[Endpoint, Endpoint, Endpoint]
+
 
 @pytest.fixture(scope='function')
 async def endpoint(event_loop: asyncio.AbstractEventLoop) -> AsyncGenerator[Endpoint, None]:
@@ -27,7 +30,7 @@ async def endpoint(event_loop: asyncio.AbstractEventLoop) -> AsyncGenerator[Endp
 
 @pytest.fixture(scope='function')
 async def pair_of_endpoints(event_loop: asyncio.AbstractEventLoop
-                            ) -> AsyncGenerator[Tuple[Endpoint, Endpoint], None]:
+                            ) -> AsyncGenerator[EndpointPair, None]:
 
     bus = EventBus()
     endpoint1 = bus.create_endpoint('e1')
@@ -40,4 +43,25 @@ async def pair_of_endpoints(event_loop: asyncio.AbstractEventLoop
     finally:
         endpoint1.stop()
         endpoint2.stop()
+        bus.stop()
+
+
+@pytest.fixture(scope="function")
+async def triplet_of_endpoints(event_loop: asyncio.AbstractEventLoop
+                               ) -> AsyncGenerator[EndpointTriplet, None]:
+
+    bus = EventBus()
+    endpoint1 = bus.create_endpoint("e1")
+    endpoint2 = bus.create_endpoint("e2")
+    endpoint3 = bus.create_endpoint("e3")
+    bus.start(event_loop)
+    await endpoint1.connect(event_loop)
+    await endpoint2.connect(event_loop)
+    await endpoint3.connect(event_loop)
+    try:
+        yield endpoint1, endpoint2, endpoint3
+    finally:
+        endpoint1.stop()
+        endpoint2.stop()
+        endpoint3.stop()
         bus.stop()

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -1,0 +1,62 @@
+from typing import (  # noqa: F401,
+    Any,
+    Callable,
+    Set,
+    Type,
+)
+
+from cytoolz import (
+    curry,
+)
+from lahja import (
+    BaseEvent,
+    BaseRequestResponseEvent,
+    Endpoint,
+)
+
+
+class DummyRequest(BaseEvent):
+    property_of_dummy_request = None
+
+
+class DummyResponse(BaseEvent):
+    property_of_dummy_response = None
+
+    def __init__(self, something: Any) -> None:
+        pass
+
+
+class DummyRequestPair(BaseRequestResponseEvent[DummyResponse]):
+    property_of_dummy_request_pair = None
+
+    @staticmethod
+    def expected_response_type() -> Type[DummyResponse]:
+        return DummyResponse
+
+
+class Tracker:
+
+    def __init__(self) -> None:
+        self._tracker: Set[int] = set()
+
+    def exists(self, track_id: int) -> bool:
+        return track_id in self._tracker
+
+    def track_and_run(self, track_id: int, continue_fn: Callable[..., Any]) -> Any:
+        """
+        Add ``track_id`` to the internal accounting and continue with ``continue_fn``
+        """
+        self._tracker.add(track_id)
+        return continue_fn()
+
+    @curry
+    def track_and_broadcast_dummy(self,
+                                  track_id: int,
+                                  endpoint: Endpoint,
+                                  ev: DummyRequestPair) -> None:
+        self.track_and_run(
+            track_id,
+            lambda: endpoint.broadcast(
+                DummyResponse(ev.property_of_dummy_request_pair), ev.broadcast_config()
+            )
+        )

--- a/tests/core/test_basics.py
+++ b/tests/core/test_basics.py
@@ -1,36 +1,16 @@
 import asyncio
-from typing import (
-    Any,
-    Type,
-)
 
 import pytest
 
+from helpers import (
+    DummyRequest,
+    DummyRequestPair,
+    DummyResponse,
+)
 from lahja import (
-    BaseEvent,
-    BaseRequestResponseEvent,
     Endpoint,
     UnexpectedResponse,
 )
-
-
-class DummyRequest(BaseEvent):
-    property_of_dummy_request = None
-
-
-class DummyResponse(BaseEvent):
-    property_of_dummy_response = None
-
-    def __init__(self, something: Any) -> None:
-        pass
-
-
-class DummyRequestPair(BaseRequestResponseEvent[DummyResponse]):
-    property_of_dummy_request_pair = None
-
-    @staticmethod
-    def expected_response_type() -> Type[DummyResponse]:
-        return DummyResponse
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_broadcast_config.py
+++ b/tests/core/test_broadcast_config.py
@@ -1,0 +1,71 @@
+from typing import (
+    Tuple,
+)
+
+import pytest
+
+from helpers import (
+    DummyRequestPair,
+    DummyResponse,
+    Tracker,
+)
+from lahja import (
+    BroadcastConfig,
+    Endpoint,
+)
+
+
+@pytest.mark.asyncio
+async def test_broadcasts_to_all_endpoints(
+        triplet_of_endpoints: Tuple[Endpoint, Endpoint, Endpoint]) -> None:
+
+    endpoint1, endpoint2, endpoint3 = triplet_of_endpoints
+
+    tracker = Tracker()
+
+    endpoint1.subscribe(
+        DummyRequestPair,
+        tracker.track_and_broadcast_dummy(1, endpoint1)
+    )
+
+    endpoint2.subscribe(
+        DummyRequestPair,
+        tracker.track_and_broadcast_dummy(2, endpoint2)
+    )
+
+    item = DummyRequestPair()
+    response = await endpoint3.request(item)
+    print(response.property_of_dummy_response)
+    assert isinstance(response, DummyResponse)
+    assert tracker.exists(1)
+    assert tracker.exists(2)
+    # Ensure the registration was cleaned up
+    assert item._id not in endpoint3._futures
+
+
+@pytest.mark.asyncio
+async def test_broadcasts_to_specific_endpoint(
+        triplet_of_endpoints: Tuple[Endpoint, Endpoint, Endpoint]) -> None:
+
+    endpoint1, endpoint2, endpoint3 = triplet_of_endpoints
+
+    tracker = Tracker()
+
+    endpoint1.subscribe(
+        DummyRequestPair,
+        tracker.track_and_broadcast_dummy(1, endpoint1)
+    )
+
+    endpoint2.subscribe(
+        DummyRequestPair,
+        tracker.track_and_broadcast_dummy(2, endpoint1)
+    )
+
+    item = DummyRequestPair()
+    response = await endpoint3.request(item, BroadcastConfig(filter_endpoint=endpoint1.name))
+    print(response.property_of_dummy_response)
+    assert isinstance(response, DummyResponse)
+    assert tracker.exists(1)
+    assert not tracker.exists(2)
+    # Ensure the registration was cleaned up
+    assert item._id not in endpoint3._futures

--- a/tests/core/test_internal.py
+++ b/tests/core/test_internal.py
@@ -1,23 +1,17 @@
 import asyncio
 from typing import (
-    Any,
     Tuple,
 )
 
 import pytest
 
+from helpers import (
+    DummyResponse,
+)
 from lahja import (
-    BaseEvent,
     BroadcastConfig,
     Endpoint,
 )
-
-
-class DummyResponse(BaseEvent):
-    property_of_dummy_response = None
-
-    def __init__(self, something: Any) -> None:
-        pass
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What was wrong?

The `request` API did not accept a `BroadcastConfig` yet. That's quite unfortunate because, often when we do a `request` we have a specific `Endpoint` in mind that would answer that request. However, without specifying a `BroadcastConfig`, the request is relayed to each and every connected `Endpoint` which obviously causes more inter process traffic than needed.

## How was it fixed?

- Make `request` API accept a `BroadcastConfig`
- added tests
- cleaned up test

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://amazinganimalphotos.com/wp-content/uploads/2013/05/adorable-lion-cub-photo.jpg)
