### PR TITLE
Do not reraise cancellations

### DIFF
--- a/lahja/endpoint.py
+++ b/lahja/endpoint.py
@@ -264,12 +264,12 @@ class Endpoint:
         while True:
             try:
                 yield await queue.get()
-            except GeneratorExit as e:
+            except GeneratorExit:
                 self._queues[event_type].remove(queue)
-                raise e
-            except asyncio.CancelledError as e:
+                break
+            except asyncio.CancelledError:
                 self._queues[event_type].remove(queue)
-                raise e
+                break
             else:
                 if i is None:
                     continue


### PR DESCRIPTION
## What was wrong?

When a stream is cancelled the exception is re-raised. I don't recall why I did that or if it was just a left over but it causes these problems in Trinity.

```
WARNING  12-07 20:34:23      DiscoveryService  Task <coroutine object DiscoveryService.handle_get_random_bootnode_requests at 0x7f45ad668150> finished unexpectedly: 
   DEBUG  12-07 20:34:23      DiscoveryService  Task failure traceback
Traceback (most recent call last):
  File "/home/cburgdorf/Documents/hacking/ef/py-evm/p2p/service.py", line 141, in _run_task_wrapper
    await awaitable
  File "/home/cburgdorf/Documents/hacking/ef/py-evm/p2p/service.py", line 160, in _run_daemon_task_wrapper
    await awaitable
  File "/home/cburgdorf/Documents/hacking/ef/py-evm/trinity/plugins/builtin/peer_discovery/discovery_service.py", line 70, in handle_get_random_bootnode_requests
    async for event in self._event_bus.stream(RandomBootnodeRequest):
  File "/home/cburgdorf/Documents/hacking/ef/py-evm/venv/lib/python3.6/site-packages/lahja/endpoint.py", line 267, in stream
    raise e
  File "/home/cburgdorf/Documents/hacking/ef/py-evm/venv/lib/python3.6/site-packages/lahja/endpoint.py", line 261, in stream
    yield await queue.get()
  File "/usr/lib/python3.6/asyncio/queues.py", line 167, in get
    yield from getter
concurrent.futures._base.CancelledError
   DEBUG  12-07 20:34:23      DiscoveryService  All tasks finished
    INFO  12-07 20:34:23     DiscoveryProtocol  stopping discovery
    INFO  12-07 20:34:23              FullNode  Timed out waiting for <trinity.nodes.full.FullNode object at 0x7fd8de625ef0> to finish its cleanup, forcibly cancelling pending tasks and exiting anyway
   DEBUG  12-07 20:34:23              FullNode  Pending tasks: [<Task pending coro=<Node.handle_network_id_requests() running at /home/cburgdorf/Documents/hacking/ef/py-evm/p2p/service.py:141> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x7fd8d7e9a738>()]>>]
 WARNING  12-07 20:34:23              FullNode  Task <coroutine object Node.handle_network_id_requests at 0x7fd8d7e7a258> finished unexpectedly: 
   DEBUG  12-07 20:34:23              FullNode  Task failure traceback
Traceback (most recent call last):
  File "/home/cburgdorf/Documents/hacking/ef/py-evm/p2p/service.py", line 141, in _run_task_wrapper
    await awaitable
  File "/home/cburgdorf/Documents/hacking/ef/py-evm/p2p/service.py", line 160, in _run_daemon_task_wrapper
    await awaitable
  File "/home/cburgdorf/Documents/hacking/ef/py-evm/trinity/nodes/base.py", line 59, in handle_network_id_requests
    async for req in self.event_bus.stream(NetworkIdRequest):
  File "/home/cburgdorf/Documents/hacking/ef/py-evm/venv/lib/python3.6/site-packages/lahja/endpoint.py", line 267, in stream
    raise e
  File "/home/cburgdorf/Documents/hacking/ef/py-evm/venv/lib/python3.6/site-packages/lahja/endpoint.py", line 261, in stream
    yield await queue.get()
  File "/usr/lib/python3.6/asyncio/queues.py", line 167, in get
    yield from getter
concurrent.futures._base.CancelledError
```

## How was it fixed?

Don't reraise these exceptions.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://files.adventure-life.com/47/31/2/8we37jvy/1500x450.jpg)
