### PR TITLE
Do not set results on futures that are cancelled or done

### DIFF
--- a/lahja/endpoint.py
+++ b/lahja/endpoint.py
@@ -145,8 +145,9 @@ class Endpoint:
 
         if in_futures:
             future = self._futures[config.filter_event_id]
-            future.set_result(item)
-            self._futures.pop(config.filter_event_id)
+            if not future.done():
+                future.set_result(item)
+            self._futures.pop(config.filter_event_id, None)
 
         if in_queue:
             for queue in self._queues[event_type]:


### PR DESCRIPTION
## What was wrong?

Currently, it seems it may happen that we run into a situation where we try to resolve a future that was already cancelled. Similarly it could *theoretically* happen that we try to set a result on a future that is already done.
 
This may be a fix for https://github.com/ethereum/py-evm/issues/1613

## How was it fixed?

Check if the future is already done or cancelled before setting the result.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://blazepress.com/.image/t_share/MTI4OTk1MTkxMTEyNzE0MjUw/2.jpg)
