### PR TITLE
Upgrade pytest libs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ from setuptools import (
 extras_require = {
     'test': [
         "cytoolz>=0.9.0,<1.0.0",
-        "pytest==3.3.2",
-        "pytest-asyncio==0.8.0",
-        "pytest-xdist",
+        "pytest==4.0.2",
+        "pytest-asyncio==0.9.0",
+        "pytest-xdist==1.25.0",
         "tox>=2.9.1,<3",
     ],
     'lint': [


### PR DESCRIPTION
## What was wrong?

Builds started failing because `pytest-xdist` (which wasn't pinned) started expecting a higher pytest version.

## How was it fixed?

Upgraded all pytest libs to their latest versions.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://get.pxhere.com/photo/nature-bird-wildlife-clean-mammal-squirrel-rodent-fauna-duck-vertebrate-fluff-waterfowl-chicks-water-bird-young-animal-ducks-geese-and-swans-555335.jpg)
