### PR TITLE
Introduce `filter_predicate` to tame event bus traffic.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ chains
 
 # tox/pytest cache
 .cache
+.pytest_cache
 
 # Test output logs
 logs

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -18,6 +18,14 @@ ConnectionConfig
     :undoc-members:
     :show-inheritance:
 
+ListenerConfig
+--------------
+
+.. autoclass:: lahja.endpoint.ListenerConfig
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Exceptions
 ----------
 

--- a/examples/inter_process_ping_pong.py
+++ b/examples/inter_process_ping_pong.py
@@ -28,7 +28,7 @@ def run_proc1():
     loop = asyncio.get_event_loop()
     endpoint = Endpoint()
     endpoint.start_serving_nowait(ConnectionConfig.from_name('e1'))
-    endpoint.connect_to_endpoints_blocking(
+    endpoint.add_listener_endpoints_blocking(
         ListenerConfig.from_name('e2')
     )
     endpoint.subscribe(SecondThingHappened, lambda event: 
@@ -54,7 +54,7 @@ def run_proc2():
     loop = asyncio.get_event_loop()
     endpoint = Endpoint()
     endpoint.start_serving_nowait(ConnectionConfig.from_name('e2'))
-    endpoint.connect_to_endpoints_blocking(
+    endpoint.add_listener_endpoints_blocking(
         ListenerConfig.from_name('e1')
     )
     endpoint.subscribe(FirstThingHappened, lambda event: 

--- a/examples/inter_process_ping_pong.py
+++ b/examples/inter_process_ping_pong.py
@@ -6,6 +6,7 @@ from lahja import (
     BaseEvent,
     Endpoint,
     ConnectionConfig,
+    ListenerConfig,
 )
 
 
@@ -28,7 +29,7 @@ def run_proc1():
     endpoint = Endpoint()
     endpoint.start_serving_nowait(ConnectionConfig.from_name('e1'))
     endpoint.connect_to_endpoints_blocking(
-        ConnectionConfig.from_name('e2')
+        ListenerConfig.from_name('e2')
     )
     endpoint.subscribe(SecondThingHappened, lambda event: 
         print("Received via SUBSCRIBE API in proc1: ", event.payload)
@@ -54,7 +55,7 @@ def run_proc2():
     endpoint = Endpoint()
     endpoint.start_serving_nowait(ConnectionConfig.from_name('e2'))
     endpoint.connect_to_endpoints_blocking(
-        ConnectionConfig.from_name('e1')
+        ListenerConfig.from_name('e1')
     )
     endpoint.subscribe(FirstThingHappened, lambda event: 
         print("Received via SUBSCRIBE API in proc2:", event.payload)

--- a/examples/request_api.py
+++ b/examples/request_api.py
@@ -31,7 +31,7 @@ def run_proc1():
     loop = asyncio.get_event_loop()
     endpoint = Endpoint()
     endpoint.start_serving_nowait(ConnectionConfig.from_name('e1'))
-    endpoint.connect_to_endpoints_blocking(
+    endpoint.add_listener_endpoints_blocking(
         ListenerConfig.from_name('e2'),
     )
     print("subscribing")
@@ -48,7 +48,7 @@ def run_proc2():
     endpoint = Endpoint()
     loop = asyncio.get_event_loop()
     endpoint.start_serving_nowait(ConnectionConfig.from_name('e2'))
-    endpoint.connect_to_endpoints_blocking(
+    endpoint.add_listener_endpoints_blocking(
         ListenerConfig.from_name('e1'),
     )
     loop.run_until_complete(proc2_worker(endpoint))

--- a/examples/request_api.py
+++ b/examples/request_api.py
@@ -8,6 +8,7 @@ from lahja import (
     BaseRequestResponseEvent,
     BroadcastConfig,
     ConnectionConfig,
+    ListenerConfig,
 )
 
 
@@ -31,7 +32,7 @@ def run_proc1():
     endpoint = Endpoint()
     endpoint.start_serving_nowait(ConnectionConfig.from_name('e1'))
     endpoint.connect_to_endpoints_blocking(
-        ConnectionConfig.from_name('e2'),
+        ListenerConfig.from_name('e2'),
     )
     print("subscribing")
     # Listen for `GetSomethingRequest`'s
@@ -48,7 +49,7 @@ def run_proc2():
     loop = asyncio.get_event_loop()
     endpoint.start_serving_nowait(ConnectionConfig.from_name('e2'))
     endpoint.connect_to_endpoints_blocking(
-        ConnectionConfig.from_name('e1'),
+        ListenerConfig.from_name('e1'),
     )
     loop.run_until_complete(proc2_worker(endpoint))
 

--- a/lahja/__init__.py
+++ b/lahja/__init__.py
@@ -1,6 +1,8 @@
 from .endpoint import (  # noqa: F401
     Endpoint,
+    filter_none,
     ConnectionConfig,
+    ListenerConfig,
 )
 from .exceptions import (  # noqa: F401
     ConnectionAttemptRejected,

--- a/lahja/endpoint.py
+++ b/lahja/endpoint.py
@@ -291,20 +291,21 @@ class Endpoint:
         server = manager.get_server()   # type: ignore
         threading.Thread(target=server.serve_forever, daemon=True).start()
 
-    def connect_to_endpoints_blocking(self, *endpoints: ListenerConfig, timeout: int=30) -> None:
+    def add_listener_endpoints_blocking(self, *endpoints: ListenerConfig, timeout: int=30) -> None:
         """
-        Connect to the given endpoints and block until the connection to every endpoint is
-        established. Raises a ``TimeoutError`` if connections do not become available within
-        ``timeout`` seconds (default 30 seconds).
+        Add the ``endpoints`` as new listeners so that they can receive events from this endpoint.
+        Block until the connection to every endpoint is established. Raises a ``TimeoutError`` if
+        connections do not become available within ``timeout`` seconds (default 30 seconds).
         """
         self._throw_if_already_connected(*endpoints)
         for endpoint in endpoints:
             wait_for_path_blocking(endpoint.path, timeout)
             self._connect_if_not_already_connected(endpoint)
 
-    async def connect_to_endpoints(self, *endpoints: ListenerConfig) -> None:
+    async def add_listener_endpoints(self, *endpoints: ListenerConfig) -> None:
         """
-        Connect to the given endpoints and await until all connections are established.
+        Add the ``endpoints`` as new listeners so that they can receive events from this endpoint.
+        Await until all connections are established.
         """
         self._throw_if_already_connected(*endpoints)
         await asyncio.gather(
@@ -312,9 +313,10 @@ class Endpoint:
             loop=self.event_loop
         )
 
-    def connect_to_endpoints_nowait(self, *endpoints: ListenerConfig) -> None:
+    def add_listener_endpoints_nowait(self, *endpoints: ListenerConfig) -> None:
         """
-        Connect to the given endpoints as soon as they become available but do not block.
+        Add the ``endpoints`` as new listeners so that they can receive events from this endpoint.
+        This API returns immediately and establishs connections as soon as they become available.
         """
         self._throw_if_already_connected(*endpoints)
         for endpoint in endpoints:

--- a/lahja/misc.py
+++ b/lahja/misc.py
@@ -24,28 +24,37 @@ class Subscription:
 class BroadcastConfig:
 
     def __init__(self,
-                 filter_endpoint: Optional[str] = None,
-                 filter_event_id: Optional[str] = None,
+                 filter_endpoint: str = '',
+                 filter_event_id: str = '',
                  internal: bool = False) -> None:
 
         self.filter_endpoint = filter_endpoint
         self.filter_event_id = filter_event_id
         self.internal = internal
 
-        if self.internal and self.filter_endpoint is not None:
+        if self.internal and len(self.filter_endpoint) > 0:
             raise ValueError("`internal` can not be used with `filter_endpoint")
 
-    def allowed_to_receive(self, endpoint: str) -> bool:
-        return self.filter_endpoint is None or self.filter_endpoint == endpoint
+    def is_not_exclusive(self) -> bool:
+        return len(self.filter_endpoint) == 0
 
 
 class BaseEvent:
 
     _origin = ''
-    _id: Optional[str] = None
+    _id: str = ''
     _config: Optional[BroadcastConfig] = None
 
     def broadcast_config(self, internal: bool = False) -> BroadcastConfig:
+        """
+        Retrieve a :class:`~lahja.misc.BroadcastConfig` based on the origin of the event. A
+        :class:`~lahja.misc.BroadcastConfig` generated through this API ensures that an event
+        will only be send to the :class:`~lahja.endpoint.Endpoint` where the origin event came
+        from. Furthermore, if the event was send using the :meth:`~lahja.endpoint.Endpoint.request`
+        API retrieving a :class:`~lahja.misc.BroadcastConfig` through this API will guarantee to
+        only propagate the event as a direct response to the callsite that initiated the origin
+        event.
+        """
         if internal:
             return BroadcastConfig(
                 internal=True,

--- a/lahja/tools/benchmark/process.py
+++ b/lahja/tools/benchmark/process.py
@@ -13,6 +13,7 @@ from lahja import (
     BroadcastConfig,
     ConnectionConfig,
     Endpoint,
+    ListenerConfig,
 )
 from lahja.tools.benchmark.constants import (
     DRIVER_ENDPOINT,
@@ -36,7 +37,7 @@ from lahja.tools.benchmark.utils.reporting import (
 
 class DriverProcessConfig(NamedTuple):
     num_events: int
-    connected_endpoints: Tuple[ConnectionConfig, ...]
+    connected_endpoints: Tuple[ListenerConfig, ...]
     throttle: float
     payload_bytes: int
 
@@ -115,7 +116,7 @@ class ConsumerProcess:
         event_bus = Endpoint()
         event_bus.start_serving_nowait(ConnectionConfig.from_name(name))
         event_bus.connect_to_endpoints_blocking(
-            ConnectionConfig.from_name(REPORTER_ENDPOINT)
+            ListenerConfig.from_name(REPORTER_ENDPOINT)
         )
         # UNCOMMENT FOR DEBUGGING
         # logger = multiprocessing.log_to_stderr()
@@ -168,6 +169,6 @@ class ReportingProcess:
         loop = asyncio.get_event_loop()
         event_bus = Endpoint()
         event_bus.start_serving_nowait(ConnectionConfig.from_name(REPORTER_ENDPOINT))
-        event_bus.connect_to_endpoints_blocking(ConnectionConfig.from_name(ROOT_ENDPOINT))
+        event_bus.connect_to_endpoints_blocking(ListenerConfig.from_name(ROOT_ENDPOINT))
 
         loop.run_until_complete(ReportingProcess.worker(event_bus, logger, config))

--- a/lahja/tools/benchmark/process.py
+++ b/lahja/tools/benchmark/process.py
@@ -60,7 +60,7 @@ class DriverProcess:
         loop = asyncio.get_event_loop()
         event_bus = Endpoint()
         event_bus.start_serving_nowait(ConnectionConfig.from_name(DRIVER_ENDPOINT))
-        event_bus.connect_to_endpoints_blocking(*config.connected_endpoints)
+        event_bus.add_listener_endpoints_blocking(*config.connected_endpoints)
         # UNCOMMENT FOR DEBUGGING
         # logger = multiprocessing.log_to_stderr()
         # logger.setLevel(logging.INFO)
@@ -115,7 +115,7 @@ class ConsumerProcess:
         loop = asyncio.get_event_loop()
         event_bus = Endpoint()
         event_bus.start_serving_nowait(ConnectionConfig.from_name(name))
-        event_bus.connect_to_endpoints_blocking(
+        event_bus.add_listener_endpoints_blocking(
             ListenerConfig.from_name(REPORTER_ENDPOINT)
         )
         # UNCOMMENT FOR DEBUGGING
@@ -169,6 +169,6 @@ class ReportingProcess:
         loop = asyncio.get_event_loop()
         event_bus = Endpoint()
         event_bus.start_serving_nowait(ConnectionConfig.from_name(REPORTER_ENDPOINT))
-        event_bus.connect_to_endpoints_blocking(ListenerConfig.from_name(ROOT_ENDPOINT))
+        event_bus.add_listener_endpoints_blocking(ListenerConfig.from_name(ROOT_ENDPOINT))
 
         loop.run_until_complete(ReportingProcess.worker(event_bus, logger, config))

--- a/lahja/tools/benchmark/utils/config.py
+++ b/lahja/tools/benchmark/utils/config.py
@@ -3,13 +3,13 @@ from typing import (
 )
 
 from lahja import (
-    ConnectionConfig,
+    ListenerConfig,
 )
 
 
-def create_consumer_endpoint_configs(num_processes: int) -> Tuple[ConnectionConfig, ...]:
+def create_consumer_endpoint_configs(num_processes: int) -> Tuple[ListenerConfig, ...]:
     return tuple(
-        ConnectionConfig.from_name(create_consumer_endpoint_name(i)) for i in range(num_processes)
+        ListenerConfig.from_name(create_consumer_endpoint_name(i)) for i in range(num_processes)
     )
 
 

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -30,7 +30,7 @@ async def endpoint(event_loop: asyncio.AbstractEventLoop) -> AsyncGenerator[Endp
     # We need to connect to our own Endpoint if we care about receiving
     # the events we broadcast. Many tests use the same Endpoint for
     # broadcasting and receiving which is a valid use case so we hook it up
-    await endpoint.connect_to_endpoints(
+    await endpoint.add_listener_endpoints(
         ListenerConfig.from_name(endpoint.name),
     )
     try:
@@ -47,10 +47,10 @@ async def pair_of_endpoints(event_loop: asyncio.AbstractEventLoop
     endpoint2 = Endpoint()
     await endpoint1.start_serving(ConnectionConfig.from_name(generate_unique_name()), event_loop)
     await endpoint2.start_serving(ConnectionConfig.from_name(generate_unique_name()), event_loop)
-    await endpoint1.connect_to_endpoints(
+    await endpoint1.add_listener_endpoints(
         ListenerConfig.from_name(endpoint2.name),
     )
-    await endpoint2.connect_to_endpoints(
+    await endpoint2.add_listener_endpoints(
         ListenerConfig.from_name(endpoint1.name),
     )
     try:
@@ -70,16 +70,16 @@ async def triplet_of_endpoints(event_loop: asyncio.AbstractEventLoop
     await endpoint1.start_serving(ConnectionConfig.from_name(generate_unique_name()), event_loop)
     await endpoint2.start_serving(ConnectionConfig.from_name(generate_unique_name()), event_loop)
     await endpoint3.start_serving(ConnectionConfig.from_name(generate_unique_name()), event_loop)
-    await endpoint1.connect_to_endpoints(
+    await endpoint1.add_listener_endpoints(
         ListenerConfig.from_name(endpoint2.name),
         ListenerConfig.from_name(endpoint3.name),
     )
 
-    await endpoint2.connect_to_endpoints(
+    await endpoint2.add_listener_endpoints(
         ListenerConfig.from_name(endpoint1.name),
         ListenerConfig.from_name(endpoint3.name),
     )
-    await endpoint3.connect_to_endpoints(
+    await endpoint3.add_listener_endpoints(
         ListenerConfig.from_name(endpoint1.name),
         ListenerConfig.from_name(endpoint2.name),
     )

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -10,6 +10,7 @@ import pytest
 from lahja import (
     ConnectionConfig,
     Endpoint,
+    ListenerConfig,
 )
 
 EndpointPair = Tuple[Endpoint, Endpoint]
@@ -30,7 +31,7 @@ async def endpoint(event_loop: asyncio.AbstractEventLoop) -> AsyncGenerator[Endp
     # the events we broadcast. Many tests use the same Endpoint for
     # broadcasting and receiving which is a valid use case so we hook it up
     await endpoint.connect_to_endpoints(
-        ConnectionConfig.from_name(endpoint.name),
+        ListenerConfig.from_name(endpoint.name),
     )
     try:
         yield endpoint
@@ -47,10 +48,10 @@ async def pair_of_endpoints(event_loop: asyncio.AbstractEventLoop
     await endpoint1.start_serving(ConnectionConfig.from_name(generate_unique_name()), event_loop)
     await endpoint2.start_serving(ConnectionConfig.from_name(generate_unique_name()), event_loop)
     await endpoint1.connect_to_endpoints(
-        ConnectionConfig.from_name(endpoint2.name),
+        ListenerConfig.from_name(endpoint2.name),
     )
     await endpoint2.connect_to_endpoints(
-        ConnectionConfig.from_name(endpoint1.name),
+        ListenerConfig.from_name(endpoint1.name),
     )
     try:
         yield endpoint1, endpoint2
@@ -70,17 +71,17 @@ async def triplet_of_endpoints(event_loop: asyncio.AbstractEventLoop
     await endpoint2.start_serving(ConnectionConfig.from_name(generate_unique_name()), event_loop)
     await endpoint3.start_serving(ConnectionConfig.from_name(generate_unique_name()), event_loop)
     await endpoint1.connect_to_endpoints(
-        ConnectionConfig.from_name(endpoint2.name),
-        ConnectionConfig.from_name(endpoint3.name),
+        ListenerConfig.from_name(endpoint2.name),
+        ListenerConfig.from_name(endpoint3.name),
     )
 
     await endpoint2.connect_to_endpoints(
-        ConnectionConfig.from_name(endpoint1.name),
-        ConnectionConfig.from_name(endpoint3.name),
+        ListenerConfig.from_name(endpoint1.name),
+        ListenerConfig.from_name(endpoint3.name),
     )
     await endpoint3.connect_to_endpoints(
-        ConnectionConfig.from_name(endpoint1.name),
-        ConnectionConfig.from_name(endpoint2.name),
+        ListenerConfig.from_name(endpoint1.name),
+        ListenerConfig.from_name(endpoint2.name),
     )
 
     try:

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -15,6 +15,12 @@ from lahja import (
 )
 
 
+class DummyEvent(BaseEvent):
+
+    def __init__(self, payload: int) -> None:
+        self.payload = payload
+
+
 class DummyRequest(BaseEvent):
     property_of_dummy_request = None
 

--- a/tests/core/test_connect.py
+++ b/tests/core/test_connect.py
@@ -23,11 +23,11 @@ async def test_can_not_connect_conflicting_names_blocking(
 
     # We connect to our own Endpoint because for this test, it doesn't matter
     # if we use a foreign one or our own
-    endpoint.connect_to_endpoints_blocking(ListenerConfig.from_connection_config(own))
+    endpoint.add_listener_endpoints_blocking(ListenerConfig.from_connection_config(own))
 
     # Can't connect a second time
     with pytest.raises(ConnectionAttemptRejected):
-        endpoint.connect_to_endpoints_blocking(ListenerConfig.from_connection_config(own))
+        endpoint.add_listener_endpoints_blocking(ListenerConfig.from_connection_config(own))
 
 
 @pytest.mark.asyncio
@@ -40,11 +40,11 @@ async def test_can_not_connect_conflicting_names(
 
     # We connect to our own Endpoint because for this test, it doesn't matter
     # if we use a foreign one or our own
-    await endpoint.connect_to_endpoints(ListenerConfig.from_connection_config(own))
+    await endpoint.add_listener_endpoints(ListenerConfig.from_connection_config(own))
 
     # Can't connect a second time
     with pytest.raises(ConnectionAttemptRejected):
-        await endpoint.connect_to_endpoints(ListenerConfig.from_connection_config(own))
+        await endpoint.add_listener_endpoints(ListenerConfig.from_connection_config(own))
 
 
 @pytest.mark.asyncio
@@ -56,7 +56,7 @@ async def test_rejects_duplicates_when_connecting_blocking(
     await endpoint.start_serving(own, event_loop)
 
     with pytest.raises(ConnectionAttemptRejected):
-        endpoint.connect_to_endpoints_blocking(
+        endpoint.add_listener_endpoints_blocking(
             ListenerConfig.from_connection_config(own),
             ListenerConfig.from_connection_config(own),
         )
@@ -71,7 +71,7 @@ async def test_rejects_duplicates_when_connecting(
     await endpoint.start_serving(own, event_loop)
 
     with pytest.raises(ConnectionAttemptRejected):
-        await endpoint.connect_to_endpoints(
+        await endpoint.add_listener_endpoints(
             ListenerConfig.from_connection_config(own),
             ListenerConfig.from_connection_config(own),
         )
@@ -86,7 +86,7 @@ async def test_rejects_duplicates_when_connecting_nowait(
     await endpoint.start_serving(own, event_loop)
 
     with pytest.raises(ConnectionAttemptRejected):
-        endpoint.connect_to_endpoints_nowait(
+        endpoint.add_listener_endpoints_nowait(
             ListenerConfig.from_connection_config(own),
             ListenerConfig.from_connection_config(own),
         )

--- a/tests/core/test_connect.py
+++ b/tests/core/test_connect.py
@@ -9,6 +9,7 @@ from lahja import (
     ConnectionAttemptRejected,
     ConnectionConfig,
     Endpoint,
+    ListenerConfig,
 )
 
 
@@ -22,11 +23,11 @@ async def test_can_not_connect_conflicting_names_blocking(
 
     # We connect to our own Endpoint because for this test, it doesn't matter
     # if we use a foreign one or our own
-    endpoint.connect_to_endpoints_blocking(own)
+    endpoint.connect_to_endpoints_blocking(ListenerConfig.from_connection_config(own))
 
     # Can't connect a second time
     with pytest.raises(ConnectionAttemptRejected):
-        endpoint.connect_to_endpoints_blocking(own)
+        endpoint.connect_to_endpoints_blocking(ListenerConfig.from_connection_config(own))
 
 
 @pytest.mark.asyncio
@@ -39,11 +40,11 @@ async def test_can_not_connect_conflicting_names(
 
     # We connect to our own Endpoint because for this test, it doesn't matter
     # if we use a foreign one or our own
-    await endpoint.connect_to_endpoints(own)
+    await endpoint.connect_to_endpoints(ListenerConfig.from_connection_config(own))
 
     # Can't connect a second time
     with pytest.raises(ConnectionAttemptRejected):
-        await endpoint.connect_to_endpoints(own)
+        await endpoint.connect_to_endpoints(ListenerConfig.from_connection_config(own))
 
 
 @pytest.mark.asyncio
@@ -55,7 +56,10 @@ async def test_rejects_duplicates_when_connecting_blocking(
     await endpoint.start_serving(own, event_loop)
 
     with pytest.raises(ConnectionAttemptRejected):
-        endpoint.connect_to_endpoints_blocking(own, own)
+        endpoint.connect_to_endpoints_blocking(
+            ListenerConfig.from_connection_config(own),
+            ListenerConfig.from_connection_config(own),
+        )
 
 
 @pytest.mark.asyncio
@@ -67,7 +71,10 @@ async def test_rejects_duplicates_when_connecting(
     await endpoint.start_serving(own, event_loop)
 
     with pytest.raises(ConnectionAttemptRejected):
-        await endpoint.connect_to_endpoints(own, own)
+        await endpoint.connect_to_endpoints(
+            ListenerConfig.from_connection_config(own),
+            ListenerConfig.from_connection_config(own),
+        )
 
 
 @pytest.mark.asyncio
@@ -79,4 +86,7 @@ async def test_rejects_duplicates_when_connecting_nowait(
     await endpoint.start_serving(own, event_loop)
 
     with pytest.raises(ConnectionAttemptRejected):
-        endpoint.connect_to_endpoints_nowait(own, own)
+        endpoint.connect_to_endpoints_nowait(
+            ListenerConfig.from_connection_config(own),
+            ListenerConfig.from_connection_config(own),
+        )

--- a/tests/core/test_filter_predicate.py
+++ b/tests/core/test_filter_predicate.py
@@ -39,7 +39,7 @@ async def endpoints_with_filter_predicate(
     def is_odd(ev: BaseEvent) -> bool:
         return not is_even(ev)
 
-    await endpoint3.connect_to_endpoints(
+    await endpoint3.add_listener_endpoints(
         ListenerConfig.from_name(endpoint1.name, filter_predicate=is_even),
         ListenerConfig.from_name(endpoint2.name, filter_predicate=is_odd),
     )

--- a/tests/core/test_filter_predicate.py
+++ b/tests/core/test_filter_predicate.py
@@ -1,0 +1,79 @@
+import asyncio
+from typing import (
+    AsyncGenerator,
+    Tuple,
+    cast,
+)
+
+import pytest
+
+from conftest import (
+    EndpointTriplet,
+    generate_unique_name,
+)
+from helpers import (
+    DummyEvent,
+)
+from lahja import (
+    BaseEvent,
+    ConnectionConfig,
+    Endpoint,
+    ListenerConfig,
+)
+
+
+@pytest.fixture(scope="function")
+async def endpoints_with_filter_predicate(
+        event_loop: asyncio.AbstractEventLoop) -> AsyncGenerator[EndpointTriplet, None]:
+
+    endpoint1 = Endpoint()
+    endpoint2 = Endpoint()
+    endpoint3 = Endpoint()
+    await endpoint1.start_serving(ConnectionConfig.from_name(generate_unique_name()), event_loop)
+    await endpoint2.start_serving(ConnectionConfig.from_name(generate_unique_name()), event_loop)
+    await endpoint3.start_serving(ConnectionConfig.from_name(generate_unique_name()), event_loop)
+
+    def is_even(ev: BaseEvent) -> bool:
+        return cast(DummyEvent, ev).payload % 2 == 0
+
+    def is_odd(ev: BaseEvent) -> bool:
+        return not is_even(ev)
+
+    await endpoint3.connect_to_endpoints(
+        ListenerConfig.from_name(endpoint1.name, filter_predicate=is_even),
+        ListenerConfig.from_name(endpoint2.name, filter_predicate=is_odd),
+    )
+
+    try:
+        yield endpoint1, endpoint2, endpoint3
+    finally:
+        endpoint1.stop()
+        endpoint2.stop()
+        endpoint3.stop()
+
+
+@pytest.mark.asyncio
+async def test_broadcasts_to_all_endpoints(
+        endpoints_with_filter_predicate: Tuple[Endpoint, Endpoint, Endpoint]) -> None:
+
+    endpoint1, endpoint2, endpoint3 = endpoints_with_filter_predicate
+    endpoint1_received = []
+    endpoint2_received = []
+
+    endpoint1.subscribe(
+        DummyEvent,
+        lambda ev: endpoint1_received.append(ev.payload)
+    )
+
+    endpoint2.subscribe(
+        DummyEvent,
+        lambda ev: endpoint2_received.append(ev.payload)
+    )
+
+    for i in range(10):
+        endpoint3.broadcast(DummyEvent(i))
+
+    await asyncio.sleep(0.01)
+
+    assert endpoint1_received == [0, 2, 4, 6, 8]
+    assert endpoint2_received == [1, 3, 5, 7, 9]

--- a/tests/core/test_stop.py
+++ b/tests/core/test_stop.py
@@ -11,6 +11,7 @@ from helpers import (
 from lahja import (
     ConnectionConfig,
     Endpoint,
+    ListenerConfig,
 )
 
 
@@ -26,8 +27,8 @@ async def test_can_stop(
     second_endpoint = Endpoint()
     await second_endpoint.start_serving(second, event_loop)
 
-    await first_endpoint.connect_to_endpoints(second)
-    await second_endpoint.connect_to_endpoints(first)
+    await first_endpoint.connect_to_endpoints(ListenerConfig.from_connection_config(second))
+    await second_endpoint.connect_to_endpoints(ListenerConfig.from_connection_config(first))
 
     first_endpoint.stop()
 

--- a/tests/core/test_stop.py
+++ b/tests/core/test_stop.py
@@ -27,8 +27,8 @@ async def test_can_stop(
     second_endpoint = Endpoint()
     await second_endpoint.start_serving(second, event_loop)
 
-    await first_endpoint.connect_to_endpoints(ListenerConfig.from_connection_config(second))
-    await second_endpoint.connect_to_endpoints(ListenerConfig.from_connection_config(first))
+    await first_endpoint.add_listener_endpoints(ListenerConfig.from_connection_config(second))
+    await second_endpoint.add_listener_endpoints(ListenerConfig.from_connection_config(first))
 
     first_endpoint.stop()
 


### PR DESCRIPTION
## What was wrong?

Obviously, the `Endpoint` provides APIs to subscribe to only specific events (`subscribe`, `stream`, `wait_for`, `request`). However, using these APIs, we do only filter events **within** our current `Endpoint` to only receive specific events at specific callsites.

But that doesn't mean these are the only events that are pushed into our `Endpoint`. Which events are pushed into which endpoints is controlled by the `Endpoint` that is broadcasting the event (Assuming we are listening to that `Endpoint` at all).

The logic for that is rather simpe so far:

1. If an `event` is only intended for a specific `Endpoint`, only push it into that `Endpoint`

2. Otherwise, push it into every listening `Endpoint`.

The producer of these events that are broadcasted over all listening endpoints does and should not care about who needs which events. However, this can become a bottleneck.

Let's use Trinity as an example. Once we start broadcasting all peer messages from the `PeerPool` across the listening endpoints, pushing every new block, receipt, transaction etc. into every listening `Endpoint` is *very* wasteful.

We may be tempted to say, "well, if a process isn't interested in these events, why listen to the `PeerPool` events at all"? Because, we may be interested in *some* of the events. E.g. the `EthStats` plugin periodically wants to now the current peer count but it does not need all the constant chatter of connected peers. 

To put out some numbers, imagine sending something to `10` processes.

```
                                                                    +++Globals+++                                                                     
|Consumer processes |   Total time   | Total aggegated time  | Propagated events  |Received events | Propagated EPS |  Received EPS  |
|        10         |    1.49226     |        7.68962        |        100         |      1000      |     67.013     |    670.126     |
                                                                +++Process Details+++                                                                 
|      Process      |Processed Events|   First sent   | Last received  |    Fastest     |    Slowest     |      AVG       | Total duration | Total aggregated time |
|    consumer_0     |      100       |  12:32:36.439  |  12:32:37.806  |    0.00115     |    0.00282     |    0.00151     |    1.36743     |        0.15127        |
|    consumer_1     |      100       |  12:32:36.439  |  12:32:37.808  |    0.00225     |    0.00521     |    0.00286     |    1.36916     |        0.28572        |
|    consumer_2     |      100       |  12:32:36.439  |  12:32:37.810  |    0.00362     |    0.00745     |    0.00424     |    1.37069     |        0.42381        |
|    consumer_3     |      100       |  12:32:36.439  |  12:32:37.812  |    0.00479     |    0.00968     |    0.00557     |    1.37288     |        0.55673        |
|    consumer_4     |      100       |  12:32:36.439  |  12:32:37.814  |    0.00586     |    0.01194     |    0.00690     |    1.37482     |        0.69032        |
|    consumer_5     |      100       |  12:32:36.439  |  12:32:37.817  |    0.00709     |    0.01427     |    0.00837     |    1.37840     |        0.83749        |
|    consumer_7     |      100       |  12:32:36.439  |  12:32:37.821  |    0.00923     |    0.01922     |    0.01116     |    1.38228     |        1.11622        |
|    consumer_6     |      100       |  12:32:36.439  |  12:32:37.819  |    0.00814     |    0.01677     |    0.00977     |    1.37999     |        0.97717        |
|    consumer_8     |      100       |  12:32:36.439  |  12:32:37.823  |    0.01021     |    0.02218     |    0.01255     |    1.38440     |        1.25522        |
|    consumer_9     |      100       |  12:32:36.439  |  12:32:37.825  |    0.01154     |    0.02634     |    0.01396     |    1.38599     |        1.39567        |
```

When actually only one of them needs it:

```
$ python scripts/perf_benchmark.py --num-processes 1 --num-events 100 --payload-bytes 1000000
                                                                    +++Globals+++                                                                     
|Consumer processes |   Total time   | Total aggegated time  | Propagated events  |Received events | Propagated EPS |  Received EPS  |
|         1         |    0.28560     |        0.23907        |        100         |      100       |    350.145     |    350.145     |
                                                                +++Process Details+++                                                                 
|      Process      |Processed Events|   First sent   | Last received  |    Fastest     |    Slowest     |      AVG       | Total duration | Total aggregated time |
|    consumer_0     |      100       |  12:33:42.726  |  12:33:42.944  |    0.00124     |    0.00631     |    0.00239     |    0.21890     |        0.23907        |

```

## How was it fixed?

With this PR, when we start listening to another `Endpoint`, we can provide a `filter_predicate`. It's a bit like `subscribe` or `stream` but on a macro level. It let's us shield from any events that we do not want to even reach our `Endpoint` because we know that no callsite is interested in it at all.

The `filter_predicate` is a `Callable[[BaseEvent], bool]` that is expected to return `True` to let an event go through or return `False` to shield from an event.

The exact rules are as follows:

1. No `filter_predicate` -> not shielding from anything
2. Events *specifically*  send to us via custom `BroadcastConfig` -> not shielded
3. Events broadcasted across all listening `Endpoints` -> only send to us if `filter_predicate(event)` returns `True`.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/12/67/aa/1267aa358c627c412f8fad4300ac2068.jpg)
