### PR TITLE
Only send subscribed messages

### DIFF
--- a/lahja/endpoint.py
+++ b/lahja/endpoint.py
@@ -133,10 +133,12 @@ class ConnectorFilter:
     def update_subscription(self) -> None:
         self.allowed_events = self.proxy.subscribed_events()
 
-    def put_nowait(self, item_and_config: Tuple[BaseEvent, Optional[BroadcastConfig]]) -> None:
+    def put_nowait(self,
+                   item_type: Type[BaseEvent],
+                   item_and_config: Tuple[BaseEvent, Optional[BroadcastConfig]]) -> None:
         item, config = item_and_config
         is_response = config is not None and config.filter_event_id
-        if type(item) in self.allowed_events or is_response:
+        if item_type in self.allowed_events or is_response:
             self.proxy.put_nowait(item_and_config)
 
 
@@ -450,7 +452,7 @@ class Endpoint:
             for name, connector in self._connected_endpoints.items():
                 allowed = (config is None) or config.allowed_to_receive(name)
                 if allowed:
-                    connector.put_nowait((compressed_item, config))
+                    connector.put_nowait(type(item), (compressed_item, config))
 
     TResponse = TypeVar('TResponse', bound=BaseEvent)
 

--- a/lahja/tools/benchmark/process.py
+++ b/lahja/tools/benchmark/process.py
@@ -60,6 +60,7 @@ class DriverProcess:
         event_bus = Endpoint()
         event_bus.start_serving_nowait(ConnectionConfig.from_name(DRIVER_ENDPOINT))
         event_bus.connect_to_endpoints_blocking(*config.connected_endpoints)
+
         # UNCOMMENT FOR DEBUGGING
         # logger = multiprocessing.log_to_stderr()
         # logger.setLevel(logging.INFO)

--- a/lahja/tools/benchmark/process.py
+++ b/lahja/tools/benchmark/process.py
@@ -4,12 +4,15 @@ import logging
 import multiprocessing
 import time
 from typing import (  # noqa: F401
+    AsyncGenerator,
     NamedTuple,
     Optional,
     Tuple,
+    TypeVar,
 )
 
 from lahja import (
+    BaseEvent,
     BroadcastConfig,
     ConnectionConfig,
     Endpoint,
@@ -41,6 +44,13 @@ class DriverProcessConfig(NamedTuple):
     payload_bytes: int
 
 
+async def wait_until_remote_endpoints_are_ready(endpoint: Endpoint) -> None:
+    for connector_filter in endpoint._connected_endpoints.values():
+        while PerfMeasureEvent not in connector_filter.allowed_events:
+            connector_filter.update_subscription()
+            await asyncio.sleep(0.1)
+
+
 class DriverProcess:
 
     def __init__(self, config: DriverProcessConfig) -> None:
@@ -68,6 +78,8 @@ class DriverProcess:
 
     @staticmethod
     async def worker(event_bus: Endpoint, config: DriverProcessConfig) -> None:
+        await wait_until_remote_endpoints_are_ready(event_bus)
+
         payload = b'\x00' * config.payload_bytes
         for n in range(config.num_events):
             await asyncio.sleep(config.throttle)
@@ -76,6 +88,28 @@ class DriverProcess:
             )
 
         event_bus.stop()
+
+
+TStreamEvent = TypeVar('TStreamEvent', bound=BaseEvent)
+TGen = AsyncGenerator[TStreamEvent, None]
+
+
+async def timed_generator(generator: TGen, timeout: int) -> TGen:
+    """
+    Wraps an asynchronous generator and throws asyncio.TimeoutError if any of the elements
+    takes longer than {timeout} to be fetched.
+    """
+    gen = generator.__aiter__()
+
+    while True:
+        try:
+            task = asyncio.ensure_future(gen.__anext__())
+            yield await asyncio.wait_for(task, timeout)
+        except StopAsyncIteration:
+            return
+        except asyncio.TimeoutError:
+            task.cancel()
+            raise
 
 
 class ConsumerProcess:
@@ -93,22 +127,30 @@ class ConsumerProcess:
         self._process.start()
 
     @staticmethod
-    async def worker(event_bus: Endpoint, num_events: int) -> None:
+    async def worker(name: str, event_bus: Endpoint, num_events: int) -> None:
         counter = itertools.count(1)
         stats = LocalStatistic()
-        async for event in event_bus.stream(PerfMeasureEvent):
-            stats.add(RawMeasureEntry(
-                sent_at=event.sent_at,
-                received_at=time.time()
-            ))
+        try:
+            async for event in timed_generator(event_bus.stream(PerfMeasureEvent), 1):
+                stats.add(RawMeasureEntry(
+                    sent_at=event.sent_at,
+                    received_at=time.time()
+                ))
 
-            if next(counter) == num_events:
-                event_bus.broadcast(
-                    TotalRecordedEvent(stats.crunch(event_bus.name)),
-                    BroadcastConfig(filter_endpoint=REPORTER_ENDPOINT)
-                )
-                event_bus.stop()
-                break
+                if next(counter) == num_events:
+                    event_bus.broadcast(
+                        TotalRecordedEvent(stats.crunch(event_bus.name)),
+                        BroadcastConfig(filter_endpoint=REPORTER_ENDPOINT)
+                    )
+                    event_bus.stop()
+                    break
+        except asyncio.TimeoutError:
+            print(f"process {name} didn't receive all the events")
+            event_bus.broadcast(
+                TotalRecordedEvent(stats.crunch(event_bus.name)),
+                BroadcastConfig(filter_endpoint=REPORTER_ENDPOINT)
+            )
+            event_bus.stop()
 
     @staticmethod
     def launch(name: str, num_events: int) -> None:
@@ -122,7 +164,7 @@ class ConsumerProcess:
         # logger = multiprocessing.log_to_stderr()
         # logger.setLevel(logging.INFO)
 
-        loop.run_until_complete(ConsumerProcess.worker(event_bus, num_events))
+        loop.run_until_complete(ConsumerProcess.worker(name, event_bus, num_events))
 
 
 class ReportingProcessConfig(NamedTuple):
@@ -153,7 +195,6 @@ class ReportingProcess:
 
         global_statistic = GlobalStatistic()
         async for event in event_bus.stream(TotalRecordedEvent):
-
             global_statistic.add(event.total)
             if len(global_statistic) == config.num_processes:
                 print_full_report(logger, config.num_processes, config.num_events, global_statistic)

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -15,6 +15,12 @@ from lahja import (
 )
 
 
+def propogate_subscriptions(*endpoints: Endpoint) -> None:
+    for endpoint in endpoints:
+        for connector_filter in endpoint._connected_endpoints.values():
+            connector_filter.update_subscription()
+
+
 class DummyRequest(BaseEvent):
     property_of_dummy_request = None
 

--- a/tests/core/test_broadcast_config.py
+++ b/tests/core/test_broadcast_config.py
@@ -8,6 +8,7 @@ from helpers import (
     DummyRequestPair,
     DummyResponse,
     Tracker,
+    propogate_subscriptions,
 )
 from lahja import (
     BroadcastConfig,
@@ -32,6 +33,8 @@ async def test_broadcasts_to_all_endpoints(
         DummyRequestPair,
         tracker.track_and_broadcast_dummy(2, endpoint2)
     )
+
+    propogate_subscriptions(endpoint1, endpoint2, endpoint3)
 
     item = DummyRequestPair()
     response = await endpoint3.request(item)
@@ -60,6 +63,8 @@ async def test_broadcasts_to_specific_endpoint(
         DummyRequestPair,
         tracker.track_and_broadcast_dummy(2, endpoint1)
     )
+
+    propogate_subscriptions(endpoint1, endpoint2, endpoint3)
 
     item = DummyRequestPair()
     response = await endpoint3.request(item, BroadcastConfig(filter_endpoint=endpoint1.name))

--- a/tests/core/test_filter_pred.py
+++ b/tests/core/test_filter_pred.py
@@ -1,0 +1,128 @@
+import asyncio
+from typing import (  # noqa: F401
+    List,
+)
+
+import pytest
+
+from conftest import (
+    generate_unique_name,
+)
+from lahja import (
+    BaseEvent,
+    BroadcastConfig,
+    ConnectionConfig,
+    Endpoint,
+)
+
+
+@pytest.mark.asyncio
+async def test_subscribed_events(event_loop: asyncio.AbstractEventLoop) -> None:
+    class TestSubscriptionEvent(BaseEvent):
+        pass
+
+    with Endpoint() as endpoint:
+        endpoint.subscribe(TestSubscriptionEvent, lambda event: None)
+
+        assert endpoint.subscribed_events == {TestSubscriptionEvent}
+
+        class TestStreamEvent(BaseEvent):
+            pass
+
+        async def stream() -> None:
+            async for _ in endpoint.stream(TestStreamEvent):  # noqa: F841
+                pass
+
+        future = asyncio.ensure_future(stream())
+        await asyncio.sleep(0)  # give stream a chance to be scheduled
+
+        assert endpoint.subscribed_events == {TestSubscriptionEvent, TestStreamEvent}
+
+        future.cancel()
+
+
+class TestEvent(BaseEvent):
+    # This must be importable in order for it to be pickleable
+    pass
+
+
+@pytest.mark.asyncio
+async def test_remote_subscribed_events(event_loop: asyncio.AbstractEventLoop) -> None:
+    with Endpoint() as local, Endpoint() as remote:
+        local.subscribe(TestEvent, lambda event: None)
+
+        assert local.subscribed_events == {TestEvent}
+
+        local_config = ConnectionConfig.from_name(generate_unique_name())
+        await local.start_serving(local_config, event_loop)
+
+        remote._loop = event_loop  # Endpoint assumes you'll serve before connecting
+        await remote.connect_to_endpoints(local_config)
+
+        proxy = remote._connected_endpoints[local_config.name]
+        assert proxy.proxy.subscribed_events() == {TestEvent}
+
+
+@pytest.mark.asyncio
+async def test_can_wait_for_changes(event_loop: asyncio.AbstractEventLoop) -> None:
+    with Endpoint() as local, Endpoint() as remote:
+        assert local.subscribed_events == set()
+
+        local_config = ConnectionConfig.from_name(generate_unique_name())
+        await local.start_serving(local_config, event_loop)
+
+        remote._loop = event_loop  # Endpoint assumes you'll serve before connecting
+        await remote.connect_to_endpoints(local_config)
+
+        proxy = remote._connected_endpoints[local_config.name]
+        assert proxy.proxy.subscribed_events() == set()
+
+        await asyncio.sleep(0.1)  # give the thread time to start
+
+        local.subscribe(TestEvent, lambda event: None)
+
+        await asyncio.sleep(0.1)  # give the thread time to update
+
+        assert proxy.proxy.subscribed_events() == {TestEvent}
+
+
+@pytest.mark.asyncio
+async def test_filtered_messages_not_sent(event_loop: asyncio.AbstractEventLoop) -> None:
+    "Test that messages we're not listening for are truly not sent"
+    class MockEndpoint(Endpoint):
+        def __init__(self) -> None:
+            super().__init__()
+            self.received_messages: List[BaseEvent] = []
+
+        def _process_item(self, item: BaseEvent, config: BroadcastConfig) -> None:
+            self.received_messages.append(item)
+
+    with MockEndpoint() as local, Endpoint() as remote:
+        local_config = ConnectionConfig.from_name(generate_unique_name())
+        await local.start_serving(local_config, event_loop)
+
+        remote_config = ConnectionConfig.from_name(generate_unique_name())
+        await remote.start_serving(remote_config, event_loop)
+        await remote.connect_to_endpoints(local_config)
+
+        assert len(local.received_messages) == 0
+
+        # We're not subscribed to the message so it better not be sent
+
+        remote.broadcast(TestEvent())
+
+        await asyncio.sleep(0.1)  # give the message time to propogate
+
+        assert len(local.received_messages) == 0
+
+        # Now, try subscribing to the message and see that it's sent
+
+        local.subscribe(TestEvent, lambda event: None)
+
+        await asyncio.sleep(0.1)  # give the thread time to update
+
+        remote.broadcast(TestEvent())
+
+        await asyncio.sleep(0.1)  # give the message time to propogate
+
+        assert len(local.received_messages) == 1


### PR DESCRIPTION
@cburgdorf Here's a prototype of a different approach to #34. This PR also only sends messages which the remote endpoint is listening for, it doesn't require any interface changes or cognitive overhead for the user, and as a bonus it dynamically changes the set of messages being listened for.

It switches on the type of the event so it doesn't support only subscribing to peer `NewTransaction` messages, for instance, but that could be added:
- `filter_predicate` parameters could be added to `subscribe()` and `stream()` and the callables sent to the remote `ConnectionFilter`s.
- the `PeerPoolMessageEvent` events could be broken up into multiple types, that would give us the best performance.

The code needs to be cleaned up a lot, so this is still a WIP, but what do you think about this approach?