### PR TITLE
Make Endpoint.broadcast() async

### DIFF
--- a/examples/inter_process_ping_pong.py
+++ b/examples/inter_process_ping_pong.py
@@ -27,7 +27,7 @@ def run_proc1():
     loop = asyncio.get_event_loop()
     endpoint = Endpoint()
     endpoint.start_serving_nowait(ConnectionConfig.from_name('e1'))
-    endpoint.connect_to_endpoints_blocking(
+    endpoint.connect_to_endpoints_nowait(
         ConnectionConfig.from_name('e2')
     )
     endpoint.subscribe(SecondThingHappened, lambda event: 
@@ -43,7 +43,7 @@ async def proc1_worker(endpoint):
     while True:
         print("Hello from proc1")
         if is_nth_second(5):
-            endpoint.broadcast(
+            await endpoint.broadcast(
                 FirstThingHappened("Hit from proc1 ({})".format(time.time()))
             )
         await asyncio.sleep(1)
@@ -53,7 +53,7 @@ def run_proc2():
     loop = asyncio.get_event_loop()
     endpoint = Endpoint()
     endpoint.start_serving_nowait(ConnectionConfig.from_name('e2'))
-    endpoint.connect_to_endpoints_blocking(
+    endpoint.connect_to_endpoints_nowait(
         ConnectionConfig.from_name('e1')
     )
     endpoint.subscribe(FirstThingHappened, lambda event: 
@@ -68,7 +68,7 @@ async def proc2_worker(endpoint):
     while True:
         print("Hello from proc2")
         if is_nth_second(2):
-            endpoint.broadcast(
+            await endpoint.broadcast(
                 SecondThingHappened("Hit from proc2 ({})".format(time.time()))
             )
         await asyncio.sleep(1)

--- a/lahja/endpoint.py
+++ b/lahja/endpoint.py
@@ -358,7 +358,7 @@ class Endpoint:
         self._receiving_queue.put_nowait((TRANSPARENT_EVENT, None))
         self._internal_queue.put_nowait((TRANSPARENT_EVENT, None))
 
-    def broadcast(self, item: BaseEvent, config: Optional[BroadcastConfig] = None) -> None:
+    async def broadcast(self, item: BaseEvent, config: Optional[BroadcastConfig] = None) -> None:
         """
         Broadcast an instance of :class:`~lahja.misc.BaseEvent` on the event bus. Takes
         an optional second parameter of :class:`~lahja.misc.BroadcastConfig` to decide
@@ -396,7 +396,7 @@ class Endpoint:
         future: asyncio.Future = asyncio.Future(loop=self.event_loop)
         self._futures[item._id] = future
 
-        self.broadcast(item, config)
+        await self.broadcast(item, config)
 
         future.add_done_callback(functools.partial(self._remove_cancelled_future, item._id))
 

--- a/lahja/endpoint.py
+++ b/lahja/endpoint.py
@@ -155,22 +155,15 @@ class Endpoint:
 
         return self._has_snappy_support
 
-    def start_serving_nowait(self,
-                             connection_config: ConnectionConfig,
-                             loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
+    async def start_serving(self, connection_config: ConnectionConfig) -> None:
         """
-        Start serving this :class:`~lahja.endpoint.Endpoint` so that it can receive events. It is
-        not guaranteed that the :class:`~lahja.endpoint.Endpoint` is fully ready after this method
-        returns. Use :meth:`~lahja.endpoint.Endpoint.start_serving` or combine with
-        :meth:`~lahja.endpoint.Endpoint.wait_until_serving`
+        Start serving this :class:`~lahja.endpoint.Endpoint` so that it can receive events. Await
+        until the :class:`~lahja.endpoint.Endpoint` is ready.
         """
-        if loop is None:
-            loop = asyncio.get_event_loop()
-
         self._name = connection_config.name
         self._ipc_path = connection_config.path
         self._create_external_api(self._ipc_path)
-        self._loop = loop
+        self._loop = asyncio.get_event_loop()
         self._internal_loop_running = asyncio.Event(loop=self.event_loop)
         self._receiving_loop_running = asyncio.Event(loop=self.event_loop)
         self._internal_queue = asyncio.Queue(loop=self.event_loop)
@@ -181,14 +174,6 @@ class Endpoint:
 
         self._running = True
 
-    async def start_serving(self,
-                            connection_config: ConnectionConfig,
-                            loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
-        """
-        Start serving this :class:`~lahja.endpoint.Endpoint` so that it can receive events. Await
-        until the :class:`~lahja.endpoint.Endpoint` is ready.
-        """
-        self.start_serving_nowait(connection_config, loop)
         await self.wait_until_serving()
 
     async def wait_until_serving(self) -> None:

--- a/lahja/endpoint.py
+++ b/lahja/endpoint.py
@@ -365,6 +365,17 @@ class Endpoint:
         where this event should be broadcasted to. By default, events are broadcasted across
         all connected endpoints with their consuming call sites.
         """
+        self.broadcast_nowait(item, config)
+
+    def broadcast_nowait(self,
+                         item: BaseEvent,
+                         config: Optional[BroadcastConfig] = None) -> None:
+        """
+        A non-async `broadcast()` (see the docstring for `broadcast()` for more)
+
+        Instead of blocking the calling coroutine this function schedules the broadcast
+        and immediately returns.
+        """
         item._origin = self.name
         if config is not None and config.internal:
             # Internal events simply bypass going through the central event bus

--- a/lahja/tools/benchmark/process.py
+++ b/lahja/tools/benchmark/process.py
@@ -70,7 +70,7 @@ class DriverProcess:
         payload = b'\x00' * config.payload_bytes
         for n in range(config.num_events):
             await asyncio.sleep(config.throttle)
-            event_bus.broadcast(
+            await event_bus.broadcast(
                 PerfMeasureEvent(payload, n, time.time())
             )
 
@@ -102,7 +102,7 @@ class ConsumerProcess:
             ))
 
             if next(counter) == num_events:
-                event_bus.broadcast(
+                await event_bus.broadcast(
                     TotalRecordedEvent(stats.crunch(event_bus.name)),
                     BroadcastConfig(filter_endpoint=REPORTER_ENDPOINT)
                 )
@@ -156,7 +156,10 @@ class ReportingProcess:
             global_statistic.add(event.total)
             if len(global_statistic) == config.num_processes:
                 print_full_report(logger, config.num_processes, config.num_events, global_statistic)
-                event_bus.broadcast(ShutdownEvent(), BroadcastConfig(filter_endpoint=ROOT_ENDPOINT))
+                await event_bus.broadcast(
+                    ShutdownEvent(),
+                    BroadcastConfig(filter_endpoint=ROOT_ENDPOINT)
+                )
                 event_bus.stop()
                 break
 

--- a/lahja/tools/benchmark/stats.py
+++ b/lahja/tools/benchmark/stats.py
@@ -19,6 +19,19 @@ class LocalStatistic:
         self._entries.append(entry)
 
     def crunch(self, caption: str) -> Total:
+        if len(self._entries) == 0:
+            return Total(
+                caption,
+                num_total=0,
+                duration_slowest=0,
+                duration_fastest=0,
+                first_sent=0,
+                last_received=0,
+                total_duration=0,
+                total_aggregated_time=0,
+                duration_avg=0,
+            )
+
         crunched_entries = []
         for entry in self._entries:
             crunched_entries.append(

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,4 +1,3 @@
-import asyncio
 from typing import (
     AsyncGenerator,
     Tuple,
@@ -22,10 +21,10 @@ def generate_unique_name() -> str:
 
 
 @pytest.fixture(scope='function')
-async def endpoint(event_loop: asyncio.AbstractEventLoop) -> AsyncGenerator[Endpoint, None]:
+async def endpoint() -> AsyncGenerator[Endpoint, None]:
 
     endpoint = Endpoint()
-    await endpoint.start_serving(ConnectionConfig.from_name(generate_unique_name()), event_loop)
+    await endpoint.start_serving(ConnectionConfig.from_name(generate_unique_name()))
     # We need to connect to our own Endpoint if we care about receiving
     # the events we broadcast. Many tests use the same Endpoint for
     # broadcasting and receiving which is a valid use case so we hook it up
@@ -39,13 +38,12 @@ async def endpoint(event_loop: asyncio.AbstractEventLoop) -> AsyncGenerator[Endp
 
 
 @pytest.fixture(scope='function')
-async def pair_of_endpoints(event_loop: asyncio.AbstractEventLoop
-                            ) -> AsyncGenerator[EndpointPair, None]:
+async def pair_of_endpoints() -> AsyncGenerator[EndpointPair, None]:
 
     endpoint1 = Endpoint()
     endpoint2 = Endpoint()
-    await endpoint1.start_serving(ConnectionConfig.from_name(generate_unique_name()), event_loop)
-    await endpoint2.start_serving(ConnectionConfig.from_name(generate_unique_name()), event_loop)
+    await endpoint1.start_serving(ConnectionConfig.from_name(generate_unique_name()))
+    await endpoint2.start_serving(ConnectionConfig.from_name(generate_unique_name()))
     await endpoint1.connect_to_endpoints(
         ConnectionConfig.from_name(endpoint2.name),
     )
@@ -60,15 +58,14 @@ async def pair_of_endpoints(event_loop: asyncio.AbstractEventLoop
 
 
 @pytest.fixture(scope="function")
-async def triplet_of_endpoints(event_loop: asyncio.AbstractEventLoop
-                               ) -> AsyncGenerator[EndpointTriplet, None]:
+async def triplet_of_endpoints() -> AsyncGenerator[EndpointTriplet, None]:
 
     endpoint1 = Endpoint()
     endpoint2 = Endpoint()
     endpoint3 = Endpoint()
-    await endpoint1.start_serving(ConnectionConfig.from_name(generate_unique_name()), event_loop)
-    await endpoint2.start_serving(ConnectionConfig.from_name(generate_unique_name()), event_loop)
-    await endpoint3.start_serving(ConnectionConfig.from_name(generate_unique_name()), event_loop)
+    await endpoint1.start_serving(ConnectionConfig.from_name(generate_unique_name()))
+    await endpoint2.start_serving(ConnectionConfig.from_name(generate_unique_name()))
+    await endpoint3.start_serving(ConnectionConfig.from_name(generate_unique_name()))
     await endpoint1.connect_to_endpoints(
         ConnectionConfig.from_name(endpoint2.name),
         ConnectionConfig.from_name(endpoint3.name),

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import (  # noqa: F401,
     Any,
     Callable,
@@ -56,7 +57,7 @@ class Tracker:
                                   ev: DummyRequestPair) -> None:
         self.track_and_run(
             track_id,
-            lambda: endpoint.broadcast(
+            lambda: asyncio.ensure_future(endpoint.broadcast(
                 DummyResponse(ev.property_of_dummy_request_pair), ev.broadcast_config()
-            )
+            ))
         )

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -1,4 +1,3 @@
-import asyncio
 from typing import (  # noqa: F401,
     Any,
     Callable,
@@ -57,7 +56,7 @@ class Tracker:
                                   ev: DummyRequestPair) -> None:
         self.track_and_run(
             track_id,
-            lambda: asyncio.ensure_future(endpoint.broadcast(
+            lambda: endpoint.broadcast_nowait(
                 DummyResponse(ev.property_of_dummy_request_pair), ev.broadcast_config()
-            ))
+            )
         )

--- a/tests/core/test_basics.py
+++ b/tests/core/test_basics.py
@@ -1,4 +1,7 @@
 import asyncio
+from typing import (
+    cast,
+)
 
 import pytest
 
@@ -21,11 +24,11 @@ from lahja import (
 async def test_request(endpoint: Endpoint) -> None:
     endpoint.subscribe(
         DummyRequestPair,
-        lambda ev: endpoint.broadcast(
+        lambda ev: cast(None, asyncio.ensure_future(endpoint.broadcast(
             # Accessing `ev.property_of_dummy_request_pair` here allows us to validate
             # mypy has the type information we think it has. We run mypy on the tests.
             DummyResponse(ev.property_of_dummy_request_pair), ev.broadcast_config()
-        )
+        )))
     )
 
     item = DummyRequestPair()
@@ -53,11 +56,11 @@ async def test_request_can_get_cancelled(endpoint: Endpoint) -> None:
 async def test_response_must_match(endpoint: Endpoint) -> None:
     endpoint.subscribe(
         DummyRequestPair,
-        lambda ev: endpoint.broadcast(
+        lambda ev: cast(None, asyncio.ensure_future(endpoint.broadcast(
             # We intentionally broadcast an unexpected response. Mypy can't catch
             # this but we ensure it is caught and raised during the processing.
             DummyRequest(), ev.broadcast_config()
-        )
+        )))
     )
 
     with pytest.raises(UnexpectedResponse):
@@ -83,7 +86,7 @@ async def test_stream_with_break(endpoint: Endpoint) -> None:
 
     # we broadcast one more item than what we consume and test for that
     for i in range(5):
-        endpoint.broadcast(DummyRequest())
+        await endpoint.broadcast(DummyRequest())
 
     await asyncio.sleep(0.01)
     # Ensure the registration was cleaned up
@@ -107,7 +110,7 @@ async def test_stream_with_num_events(endpoint: Endpoint) -> None:
 
     # we broadcast one more item than what we consume and test for that
     for i in range(3):
-        endpoint.broadcast(DummyRequest())
+        await endpoint.broadcast(DummyRequest())
 
     await asyncio.sleep(0.01)
     # Ensure the registration was cleaned up
@@ -140,7 +143,7 @@ async def test_stream_can_get_cancelled(endpoint: Endpoint) -> None:
     asyncio.ensure_future(cancel_soon())
 
     for i in range(50):
-        endpoint.broadcast(DummyRequest())
+        await endpoint.broadcast(DummyRequest())
 
     await asyncio.sleep(0.2)
     # Ensure the registration was cleaned up
@@ -173,7 +176,7 @@ async def test_stream_cancels_when_parent_task_is_cancelled(endpoint: Endpoint) 
     asyncio.ensure_future(cancel_soon())
 
     for i in range(10):
-        endpoint.broadcast(DummyRequest())
+        await endpoint.broadcast(DummyRequest())
 
     await asyncio.sleep(0.1)
     # Ensure the registration was cleaned up
@@ -194,7 +197,7 @@ async def test_wait_for(endpoint: Endpoint) -> None:
         received = request
 
     asyncio.ensure_future(stream_response())
-    endpoint.broadcast(DummyRequest())
+    await endpoint.broadcast(DummyRequest())
 
     await asyncio.sleep(0.01)
     assert isinstance(received, DummyRequest)

--- a/tests/core/test_basics.py
+++ b/tests/core/test_basics.py
@@ -228,7 +228,7 @@ async def test_exceptions_dont_stop_processing(capsys: SysCapture,
     endpoint.subscribe(RemoveItem, handle)
 
     # this call should work
-    endpoint.broadcast(RemoveItem(1))
+    await endpoint.broadcast(RemoveItem(1))
     await asyncio.sleep(0.05)
     assert the_set == {3}
 
@@ -236,7 +236,7 @@ async def test_exceptions_dont_stop_processing(capsys: SysCapture,
     assert len(captured.err) == 0
 
     # this call causes an exception
-    endpoint.broadcast(RemoveItem(2))
+    await endpoint.broadcast(RemoveItem(2))
     await asyncio.sleep(0.05)
     assert the_set == {3}
 
@@ -244,6 +244,6 @@ async def test_exceptions_dont_stop_processing(capsys: SysCapture,
     assert len(captured.err) > 0
 
     # despite the previous exception this message should get through
-    endpoint.broadcast(RemoveItem(3))
+    await endpoint.broadcast(RemoveItem(3))
     await asyncio.sleep(0.05)
     assert the_set == set()

--- a/tests/core/test_basics.py
+++ b/tests/core/test_basics.py
@@ -1,7 +1,4 @@
 import asyncio
-from typing import (
-    cast,
-)
 
 import pytest
 
@@ -24,11 +21,11 @@ from lahja import (
 async def test_request(endpoint: Endpoint) -> None:
     endpoint.subscribe(
         DummyRequestPair,
-        lambda ev: cast(None, asyncio.ensure_future(endpoint.broadcast(
+        lambda ev: endpoint.broadcast_nowait(
             # Accessing `ev.property_of_dummy_request_pair` here allows us to validate
             # mypy has the type information we think it has. We run mypy on the tests.
             DummyResponse(ev.property_of_dummy_request_pair), ev.broadcast_config()
-        )))
+        )
     )
 
     item = DummyRequestPair()
@@ -56,11 +53,11 @@ async def test_request_can_get_cancelled(endpoint: Endpoint) -> None:
 async def test_response_must_match(endpoint: Endpoint) -> None:
     endpoint.subscribe(
         DummyRequestPair,
-        lambda ev: cast(None, asyncio.ensure_future(endpoint.broadcast(
+        lambda ev: endpoint.broadcast_nowait(
             # We intentionally broadcast an unexpected response. Mypy can't catch
             # this but we ensure it is caught and raised during the processing.
             DummyRequest(), ev.broadcast_config()
-        )))
+        )
     )
 
     with pytest.raises(UnexpectedResponse):

--- a/tests/core/test_connect.py
+++ b/tests/core/test_connect.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import pytest
 
 from conftest import (
@@ -13,12 +11,11 @@ from lahja import (
 
 
 @pytest.mark.asyncio
-async def test_can_not_connect_conflicting_names_blocking(
-        event_loop: asyncio.AbstractEventLoop) -> None:
+async def test_can_not_connect_conflicting_names_blocking() -> None:
 
     own = ConnectionConfig.from_name(generate_unique_name())
     endpoint = Endpoint()
-    await endpoint.start_serving(own, event_loop)
+    await endpoint.start_serving(own)
 
     # We connect to our own Endpoint because for this test, it doesn't matter
     # if we use a foreign one or our own
@@ -30,12 +27,11 @@ async def test_can_not_connect_conflicting_names_blocking(
 
 
 @pytest.mark.asyncio
-async def test_can_not_connect_conflicting_names(
-        event_loop: asyncio.AbstractEventLoop) -> None:
+async def test_can_not_connect_conflicting_names() -> None:
 
     own = ConnectionConfig.from_name(generate_unique_name())
     endpoint = Endpoint()
-    await endpoint.start_serving(own, event_loop)
+    await endpoint.start_serving(own)
 
     # We connect to our own Endpoint because for this test, it doesn't matter
     # if we use a foreign one or our own
@@ -47,36 +43,33 @@ async def test_can_not_connect_conflicting_names(
 
 
 @pytest.mark.asyncio
-async def test_rejects_duplicates_when_connecting_blocking(
-        event_loop: asyncio.AbstractEventLoop) -> None:
+async def test_rejects_duplicates_when_connecting_blocking() -> None:
 
     own = ConnectionConfig.from_name(generate_unique_name())
     endpoint = Endpoint()
-    await endpoint.start_serving(own, event_loop)
+    await endpoint.start_serving(own)
 
     with pytest.raises(ConnectionAttemptRejected):
         endpoint.connect_to_endpoints_blocking(own, own)
 
 
 @pytest.mark.asyncio
-async def test_rejects_duplicates_when_connecting(
-        event_loop: asyncio.AbstractEventLoop) -> None:
+async def test_rejects_duplicates_when_connecting() -> None:
 
     own = ConnectionConfig.from_name(generate_unique_name())
     endpoint = Endpoint()
-    await endpoint.start_serving(own, event_loop)
+    await endpoint.start_serving(own)
 
     with pytest.raises(ConnectionAttemptRejected):
         await endpoint.connect_to_endpoints(own, own)
 
 
 @pytest.mark.asyncio
-async def test_rejects_duplicates_when_connecting_nowait(
-        event_loop: asyncio.AbstractEventLoop) -> None:
+async def test_rejects_duplicates_when_connecting_nowait() -> None:
 
     own = ConnectionConfig.from_name(generate_unique_name())
     endpoint = Endpoint()
-    await endpoint.start_serving(own, event_loop)
+    await endpoint.start_serving(own)
 
     with pytest.raises(ConnectionAttemptRejected):
         endpoint.connect_to_endpoints_nowait(own, own)

--- a/tests/core/test_internal.py
+++ b/tests/core/test_internal.py
@@ -22,7 +22,7 @@ async def test_internal_propagation(pair_of_endpoints: Tuple[Endpoint, Endpoint]
     async def broadcast_dummies() -> None:
         while True:
             # We are broadcasting internally on endpoint1
-            endpoint1.broadcast(
+            await endpoint1.broadcast(
                 DummyResponse("Dummy"),
                 BroadcastConfig(internal=True)
             )

--- a/tests/core/test_stop.py
+++ b/tests/core/test_stop.py
@@ -31,4 +31,4 @@ async def test_can_stop(
 
     first_endpoint.stop()
 
-    second_endpoint.broadcast(DummyResponse(None))
+    await second_endpoint.broadcast(DummyResponse(None))

--- a/tests/core/test_stop.py
+++ b/tests/core/test_stop.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import pytest
 
 from conftest import (
@@ -15,16 +13,15 @@ from lahja import (
 
 
 @pytest.mark.asyncio
-async def test_can_stop(
-        event_loop: asyncio.AbstractEventLoop) -> None:
+async def test_can_stop() -> None:
 
     first = ConnectionConfig.from_name(generate_unique_name())
     first_endpoint = Endpoint()
-    await first_endpoint.start_serving(first, event_loop)
+    await first_endpoint.start_serving(first)
 
     second = ConnectionConfig.from_name(generate_unique_name())
     second_endpoint = Endpoint()
-    await second_endpoint.start_serving(second, event_loop)
+    await second_endpoint.start_serving(second)
 
     await first_endpoint.connect_to_endpoints(second)
     await second_endpoint.connect_to_endpoints(first)


### PR DESCRIPTION
## What was wrong?

While working on #39 I attempted to make `Endpoint.broadcast()` async. That PR uses asyncio to communicate with other Endpoints, so any caller attempting to `broadcast()` must either be a coroutine which is okay with being blocked or call `asyncio.ensure_future`.

This PR makes some interface changes:
- `Endpoint.broadcast()` is now async
- `Endpoint.broadcast_nowait()` now exists and does what `Endpoint.broadcast()` used to do.
- `start_serving_nowait()` no longer exists. Callers must use `Endpoint.start_serving()`.
- `start_serving()` no longer accepts an event loop, it uses the current event loop.

I don't believe that this PR meaningfully changes behavior, but Christoph pointed out that #39, the reason for this PR, will block calling coroutines if other processes manage to block their own event loops. I think this is okay, because the other alternatives I see are:
- drop messages to remotes which are taking too long to process messages
- allow the local queue of messages to be sent to grow unboundedly

And both of those sound worse to me than bad performance.

I've also opened a PR against trinity which uses this branch: https://github.com/ethereum/trinity/pull/538

#### Cute Animal Picture

![elephant](https://user-images.githubusercontent.com/466333/56707699-c2435700-66ce-11e9-9f7a-39a076019f39.jpg)

