### PR TITLE
Release 0.12.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.11.2
+current_version = 0.12.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,21 @@
 Release Notes
 =============
 
+v0.12.0
+-------
+
+- Change IPC backend from multiprocessing to asyncio
+- Endpoint.broadcast() is now async
+- Endpoint.broadcast_nowait() now exists, it schedules the message to be broadcast
+- Endpoint.start_serving_nowait() no longer exists
+- Endpoint.connect_to_endpoints_blocking() no longer exists
+- Endpoint.stop() must be called or else some coroutines will be orphaned
+- Endpoint can only be used from one event loop. It will remember the current event loop
+  when an async method is first called, and throw an exception if another of its async
+  methods is called from a different event loop.
+- Messages will be compressed if python-snappy is installed
+- Lahja previously silently dropped some exceptions, they are now propogated up
+
 v0.11.2
 -------
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ extras_require['dev'] = (
 setup(
     name='lahja',
     # *IMPORTANT*: Don't manually change the version here. Use `make bump`, as described in readme
-    version='0.11.2',
+    version='0.12.0',
     description="Generic event bus for inter process asyncio communication",
     long_description_markdown_filename='README.md',
     author='The Lahja developers',


### PR DESCRIPTION
## What was wrong?

A new lahja version needs to be released for https://github.com/ethereum/trinity/pull/556 to be mergable. 

## How was it fixed?

Here are some candidate release notes. I think that I've done everything I can do from [this list](https://github.com/ethereum/snake-charmers-tactical-manual/blob/master/cutting-a-release.md) without access to pypi. Do these release notes look good? How should I go about getting access to pypi & readthedocs?

#### Cute Animal Picture

![soaring-eagle-1](https://user-images.githubusercontent.com/466333/57338168-39221c00-70e1-11e9-851c-0d771dd4d408.jpg)

