### PR TITLE
Simplify snappy support check

### DIFF
--- a/lahja/_snappy.py
+++ b/lahja/_snappy.py
@@ -1,0 +1,7 @@
+is_snappy_available: bool
+
+try:
+    import snappy  # noqa: F401
+    is_snappy_available = True
+except ModuleNotFoundError:
+    is_snappy_available = False

--- a/lahja/_snappy.py
+++ b/lahja/_snappy.py
@@ -1,7 +1,8 @@
-is_snappy_available: bool
 
-try:
-    import snappy  # noqa: F401
-    is_snappy_available = True
-except ModuleNotFoundError:
-    is_snappy_available = False
+
+def check_has_snappy_support() -> bool:
+    try:
+        import snappy  # noqa: F401
+        return True
+    except ModuleNotFoundError:
+        return False

--- a/lahja/endpoint.py
+++ b/lahja/endpoint.py
@@ -198,12 +198,8 @@ class Endpoint:
     @property
     def has_snappy_support(self) -> bool:
         if self._has_snappy_support is None:
-            try:
-                import snappy  # noqa: F401
-                self._has_snappy_support = True
-            except ModuleNotFoundError:
-                self._has_snappy_support = False
-
+            from lahja._snappy import is_snappy_available
+            self._has_snappy_support = is_snappy_available
         return self._has_snappy_support
 
     @check_event_loop

--- a/lahja/endpoint.py
+++ b/lahja/endpoint.py
@@ -29,6 +29,10 @@ from typing import (  # noqa: F401
 )
 import uuid
 
+from lahja._snappy import (
+    check_has_snappy_support,
+)
+
 from ._utils import (
     wait_for_path,
 )
@@ -140,8 +144,6 @@ class Endpoint:
 
     _loop: Optional[asyncio.AbstractEventLoop]
 
-    _has_snappy_support: Optional[bool] = None
-
     def __init__(self) -> None:
         self._connected_endpoints: Dict[str, RemoteEndpoint] = {}
         self._futures: Dict[Optional[str], asyncio.Future] = {}
@@ -195,12 +197,10 @@ class Endpoint:
     def name(self) -> str:
         return self._name
 
-    @property
-    def has_snappy_support(self) -> bool:
-        if self._has_snappy_support is None:
-            from lahja._snappy import is_snappy_available
-            self._has_snappy_support = is_snappy_available
-        return self._has_snappy_support
+    # This property gets assigned during class creation.  This should be ok
+    # since snappy support is defined as the module being importable and that
+    # should not change during the lifecycle of the python process.
+    has_snappy_support = check_has_snappy_support()
 
     @check_event_loop
     async def start_serving(self, connection_config: ConnectionConfig) -> None:


### PR DESCRIPTION
## What was wrong?

Snappy support check should be re-usable.  

## How was it fixed?

Moved it to a private namespace and made it easy to import without having to do error checking every place we want to check.

#### Cute Animal Picture

![Cute-Goats-Photo-15](https://user-images.githubusercontent.com/824194/57467044-05f59f00-723f-11e9-93e2-d6a573398071.jpg)

