### PR TITLE
Remove type hints from tests

### DIFF
--- a/lahja/__init__.py
+++ b/lahja/__init__.py
@@ -1,6 +1,6 @@
 from .endpoint import (  # noqa: F401
-    Endpoint,
     ConnectionConfig,
+    Endpoint,
 )
 from .exceptions import (  # noqa: F401
     ConnectionAttemptRejected,

--- a/lahja/endpoint.py
+++ b/lahja/endpoint.py
@@ -154,7 +154,7 @@ class Endpoint:
         self._handler: Dict[Type[BaseEvent], List[Callable[[BaseEvent], Any]]] = {}
         self._queues: Dict[Type[BaseEvent], List['asyncio.Queue[BaseEvent]']] = {}
 
-        self._child_coros: Set[asyncio.Future[Any]] = set()
+        self._child_coros: Set['asyncio.Future[Any]'] = set()
 
         self._running = False
         self._loop = None
@@ -479,7 +479,7 @@ class Endpoint:
 
         return result
 
-    def _remove_cancelled_future(self, id: str, future: asyncio.Future[Any]) -> None:
+    def _remove_cancelled_future(self, id: str, future: 'asyncio.Future[Any]') -> None:
         try:
             future.exception()
         except asyncio.CancelledError:

--- a/lahja/tools/benchmark/__init__.py
+++ b/lahja/tools/benchmark/__init__.py
@@ -1,1 +1,3 @@
-from .stats import LocalStatistic  # noqa: F401
+from .stats import (  # noqa: F401
+    LocalStatistic,
+)

--- a/lahja/tools/benchmark/process.py
+++ b/lahja/tools/benchmark/process.py
@@ -110,17 +110,6 @@ class ConsumerProcess:
         loop.run_until_complete(ConsumerProcess.worker(name, num_events))
 
     @staticmethod
-    async def gen_with_timeout(generator: AsyncGenerator, timeout: int) -> AsyncGenerator:
-        try:
-            while True:
-                # the asyncio.TimeoutError is the caller's responsibility
-                future = asyncio.ensure_future(generator.__anext__())
-                future.add_done_callback(lambda x: None)
-                yield await asyncio.wait_for(future, timeout=timeout)
-        except StopAsyncIteration:
-            pass
-
-    @staticmethod
     async def worker(name: str, num_events: int) -> None:
         with Endpoint() as event_bus:
             await event_bus.start_serving(ConnectionConfig.from_name(name))

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras_require = {
     'lint': [
         "flake8==3.4.1",
         "isort==4.3.4",
-        "mypy==0.620",
+        "mypy==0.701",
     ],
     'doc': [
         "Sphinx>=1.6.5,<2",

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,7 +1,3 @@
-from typing import (
-    AsyncGenerator,
-    Tuple,
-)
 import uuid
 
 import pytest
@@ -11,17 +7,14 @@ from lahja import (
     Endpoint,
 )
 
-EndpointPair = Tuple[Endpoint, Endpoint]
-EndpointTriplet = Tuple[Endpoint, Endpoint, Endpoint]
 
-
-def generate_unique_name() -> str:
+def generate_unique_name():
     # We use unique names to avoid clashing of IPC pipes
     return str(uuid.uuid4())
 
 
 @pytest.fixture(scope='function')
-async def endpoint() -> AsyncGenerator[Endpoint, None]:
+async def endpoint():
 
     endpoint = Endpoint()
     await endpoint.start_serving(ConnectionConfig.from_name(generate_unique_name()))
@@ -38,7 +31,7 @@ async def endpoint() -> AsyncGenerator[Endpoint, None]:
 
 
 @pytest.fixture(scope='function')
-async def pair_of_endpoints() -> AsyncGenerator[EndpointPair, None]:
+async def pair_of_endpoints():
 
     endpoint1 = Endpoint()
     endpoint2 = Endpoint()
@@ -58,7 +51,7 @@ async def pair_of_endpoints() -> AsyncGenerator[EndpointPair, None]:
 
 
 @pytest.fixture(scope="function")
-async def triplet_of_endpoints() -> AsyncGenerator[EndpointTriplet, None]:
+async def triplet_of_endpoints():
 
     endpoint1 = Endpoint()
     endpoint2 = Endpoint()

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -11,7 +11,6 @@ from cytoolz import (
 from lahja import (
     BaseEvent,
     BaseRequestResponseEvent,
-    Endpoint,
 )
 
 
@@ -22,7 +21,7 @@ class DummyRequest(BaseEvent):
 class DummyResponse(BaseEvent):
     property_of_dummy_response = None
 
-    def __init__(self, something: Any) -> None:
+    def __init__(self, something):
         pass
 
 
@@ -30,19 +29,19 @@ class DummyRequestPair(BaseRequestResponseEvent[DummyResponse]):
     property_of_dummy_request_pair = None
 
     @staticmethod
-    def expected_response_type() -> Type[DummyResponse]:
+    def expected_response_type():
         return DummyResponse
 
 
 class Tracker:
 
-    def __init__(self) -> None:
-        self._tracker: Set[int] = set()
+    def __init__(self):
+        self._tracker = set()
 
-    def exists(self, track_id: int) -> bool:
+    def exists(self, track_id):
         return track_id in self._tracker
 
-    def track_and_run(self, track_id: int, continue_fn: Callable[..., Any]) -> Any:
+    def track_and_run(self, track_id, continue_fn):
         """
         Add ``track_id`` to the internal accounting and continue with ``continue_fn``
         """
@@ -51,9 +50,9 @@ class Tracker:
 
     @curry
     def track_and_broadcast_dummy(self,
-                                  track_id: int,
-                                  endpoint: Endpoint,
-                                  ev: DummyRequestPair) -> None:
+                                  track_id,
+                                  endpoint,
+                                  ev):
         self.track_and_run(
             track_id,
             lambda: endpoint.broadcast_nowait(

--- a/tests/core/test_basics.py
+++ b/tests/core/test_basics.py
@@ -3,9 +3,6 @@ import pickle
 
 import pytest
 
-from _pytest.capture import (
-    SysCapture,
-)
 from helpers import (
     DummyRequest,
     DummyRequestPair,
@@ -19,7 +16,7 @@ from lahja import (
 
 
 @pytest.mark.asyncio
-async def test_request(endpoint: Endpoint) -> None:
+async def test_request(endpoint):
     endpoint.subscribe(
         DummyRequestPair,
         lambda ev: endpoint.broadcast_nowait(
@@ -40,7 +37,7 @@ async def test_request(endpoint: Endpoint) -> None:
 
 
 @pytest.mark.asyncio
-async def test_request_can_get_cancelled(endpoint: Endpoint) -> None:
+async def test_request_can_get_cancelled(endpoint):
 
     item = DummyRequestPair()
     with pytest.raises(asyncio.TimeoutError):
@@ -51,7 +48,7 @@ async def test_request_can_get_cancelled(endpoint: Endpoint) -> None:
 
 
 @pytest.mark.asyncio
-async def test_response_must_match(endpoint: Endpoint) -> None:
+async def test_response_must_match(endpoint):
     endpoint.subscribe(
         DummyRequestPair,
         lambda ev: endpoint.broadcast_nowait(
@@ -66,10 +63,10 @@ async def test_response_must_match(endpoint: Endpoint) -> None:
 
 
 @pytest.mark.asyncio
-async def test_stream_with_break(endpoint: Endpoint) -> None:
+async def test_stream_with_break(endpoint):
     stream_counter = 0
 
-    async def stream_response() -> None:
+    async def stream_response():
         async for event in endpoint.stream(DummyRequest):
             # Accessing `ev.property_of_dummy_request` here allows us to validate
             # mypy has the type information we think it has. We run mypy on the tests.
@@ -93,10 +90,10 @@ async def test_stream_with_break(endpoint: Endpoint) -> None:
 
 
 @pytest.mark.asyncio
-async def test_stream_with_num_events(endpoint: Endpoint) -> None:
+async def test_stream_with_num_events(endpoint):
     stream_counter = 0
 
-    async def stream_response() -> None:
+    async def stream_response():
         nonlocal stream_counter
         async for event in endpoint.stream(DummyRequest, num_events=2):
             # Accessing `ev.property_of_dummy_request` here allows us to validate
@@ -117,12 +114,12 @@ async def test_stream_with_num_events(endpoint: Endpoint) -> None:
 
 
 @pytest.mark.asyncio
-async def test_stream_can_get_cancelled(endpoint: Endpoint) -> None:
+async def test_stream_can_get_cancelled(endpoint):
     stream_counter = 0
 
     async_generator = endpoint.stream(DummyRequest)
 
-    async def stream_response() -> None:
+    async def stream_response():
         nonlocal stream_counter
         async for event in async_generator:
             # Accessing `ev.property_of_dummy_request` here allows us to validate
@@ -131,7 +128,7 @@ async def test_stream_can_get_cancelled(endpoint: Endpoint) -> None:
             stream_counter += 1
             await asyncio.sleep(0.1)
 
-    async def cancel_soon() -> None:
+    async def cancel_soon():
         while True:
             await asyncio.sleep(0.01)
             if stream_counter == 2:
@@ -154,10 +151,10 @@ async def test_stream_can_get_cancelled(endpoint: Endpoint) -> None:
 
 
 @pytest.mark.asyncio
-async def test_stream_cancels_when_parent_task_is_cancelled(endpoint: Endpoint) -> None:
+async def test_stream_cancels_when_parent_task_is_cancelled(endpoint):
     stream_counter = 0
 
-    async def stream_response() -> None:
+    async def stream_response():
         nonlocal stream_counter
         async for event in endpoint.stream(DummyRequest):
             # Accessing `ev.property_of_dummy_request` here allows us to validate
@@ -168,7 +165,7 @@ async def test_stream_cancels_when_parent_task_is_cancelled(endpoint: Endpoint) 
 
     task = asyncio.ensure_future(stream_response())
 
-    async def cancel_soon() -> None:
+    async def cancel_soon():
         while True:
             await asyncio.sleep(0.01)
             if stream_counter == 2:
@@ -187,10 +184,10 @@ async def test_stream_cancels_when_parent_task_is_cancelled(endpoint: Endpoint) 
 
 
 @pytest.mark.asyncio
-async def test_wait_for(endpoint: Endpoint) -> None:
+async def test_wait_for(endpoint):
     received = None
 
-    async def stream_response() -> None:
+    async def stream_response():
         request = await endpoint.wait_for(DummyRequest)
         # Accessing `ev.property_of_dummy_request` here allows us to validate
         # mypy has the type information we think it has. We run mypy on the tests.
@@ -206,7 +203,7 @@ async def test_wait_for(endpoint: Endpoint) -> None:
 
 
 @pytest.mark.asyncio
-async def test_wait_for_can_get_cancelled(endpoint: Endpoint) -> None:
+async def test_wait_for_can_get_cancelled(endpoint):
 
     with pytest.raises(asyncio.TimeoutError):
         await asyncio.wait_for(endpoint.wait_for(DummyRequest), 0.01)
@@ -216,18 +213,17 @@ async def test_wait_for_can_get_cancelled(endpoint: Endpoint) -> None:
 
 
 class RemoveItem(BaseEvent):
-    def __init__(self, item: int) -> None:
+    def __init__(self, item):
         super().__init__()
         self.item = item
 
 
 @pytest.mark.asyncio
-async def test_exceptions_dont_stop_processing(capsys: SysCapture,
-                                               endpoint: Endpoint) -> None:
+async def test_exceptions_dont_stop_processing(capsys, endpoint):
 
     the_set = {1, 3}
 
-    def handle(message: RemoveItem) -> None:
+    def handle(message):
         the_set.remove(message.item)
 
     endpoint.subscribe(RemoveItem, handle)
@@ -254,7 +250,7 @@ async def test_exceptions_dont_stop_processing(capsys: SysCapture,
     assert the_set == set()
 
 
-def test_pickle_fails() -> None:
+def test_pickle_fails():
     endpoint = Endpoint()
 
     with pytest.raises(Exception):

--- a/tests/core/test_broadcast_config.py
+++ b/tests/core/test_broadcast_config.py
@@ -1,7 +1,3 @@
-from typing import (
-    Tuple,
-)
-
 import pytest
 
 from helpers import (
@@ -11,13 +7,11 @@ from helpers import (
 )
 from lahja import (
     BroadcastConfig,
-    Endpoint,
 )
 
 
 @pytest.mark.asyncio
-async def test_broadcasts_to_all_endpoints(
-        triplet_of_endpoints: Tuple[Endpoint, Endpoint, Endpoint]) -> None:
+async def test_broadcasts_to_all_endpoints(triplet_of_endpoints):
 
     endpoint1, endpoint2, endpoint3 = triplet_of_endpoints
 
@@ -48,8 +42,7 @@ async def test_broadcasts_to_all_endpoints(
 
 
 @pytest.mark.asyncio
-async def test_broadcasts_to_specific_endpoint(
-        triplet_of_endpoints: Tuple[Endpoint, Endpoint, Endpoint]) -> None:
+async def test_broadcasts_to_specific_endpoint(triplet_of_endpoints):
 
     endpoint1, endpoint2, endpoint3 = triplet_of_endpoints
 

--- a/tests/core/test_connect.py
+++ b/tests/core/test_connect.py
@@ -11,7 +11,7 @@ from lahja import (
 
 
 @pytest.mark.asyncio
-async def test_can_not_connect_conflicting_names() -> None:
+async def test_can_not_connect_conflicting_names():
 
     own = ConnectionConfig.from_name(generate_unique_name())
     endpoint = Endpoint()
@@ -29,7 +29,7 @@ async def test_can_not_connect_conflicting_names() -> None:
 
 
 @pytest.mark.asyncio
-async def test_rejects_duplicates_when_connecting() -> None:
+async def test_rejects_duplicates_when_connecting():
 
     own = ConnectionConfig.from_name(generate_unique_name())
     endpoint = Endpoint()
@@ -42,7 +42,7 @@ async def test_rejects_duplicates_when_connecting() -> None:
 
 
 @pytest.mark.asyncio
-async def test_rejects_duplicates_when_connecting_nowait() -> None:
+async def test_rejects_duplicates_when_connecting_nowait():
 
     own = ConnectionConfig.from_name(generate_unique_name())
     endpoint = Endpoint()

--- a/tests/core/test_import.py
+++ b/tests/core/test_import.py
@@ -1,4 +1,4 @@
 
 
-def test_import() -> None:
+def test_import():
     import lahja  # noqa: F401

--- a/tests/core/test_internal.py
+++ b/tests/core/test_internal.py
@@ -1,7 +1,4 @@
 import asyncio
-from typing import (
-    Tuple,
-)
 
 import pytest
 
@@ -10,16 +7,15 @@ from helpers import (
 )
 from lahja import (
     BroadcastConfig,
-    Endpoint,
 )
 
 
 @pytest.mark.asyncio
-async def test_internal_propagation(pair_of_endpoints: Tuple[Endpoint, Endpoint]) -> None:
+async def test_internal_propagation(pair_of_endpoints):
 
     endpoint1, endpoint2 = pair_of_endpoints
 
-    async def broadcast_dummies() -> None:
+    async def broadcast_dummies():
         while True:
             # We are broadcasting internally on endpoint1
             await endpoint1.broadcast(

--- a/tests/core/test_stop.py
+++ b/tests/core/test_stop.py
@@ -13,7 +13,7 @@ from lahja import (
 
 
 @pytest.mark.asyncio
-async def test_can_stop() -> None:
+async def test_can_stop():
 
     first = ConnectionConfig.from_name(generate_unique_name())
     first_endpoint = Endpoint()

--- a/tests/mypy_typing_test.py
+++ b/tests/mypy_typing_test.py
@@ -1,4 +1,8 @@
-from typing import AsyncIterable, Type
+from typing import (
+    AsyncIterable,
+    Type,
+)
+
 from lahja import (
     BaseEvent,
     BaseRequestResponseEvent,
@@ -27,3 +31,9 @@ async def verify_stream_type(endpoint: Endpoint) -> AsyncIterable[Event]:
 
 async def verify_request_response_type(endpoint: Endpoint) -> Event:
     return await endpoint.request(RequestEvent())
+
+
+async def verify_subscribe_type(endpoint: Endpoint) -> None:
+    def handler(event: Event) -> None:
+        pass
+    endpoint.subscribe(Event, handler)

--- a/tests/mypy_typing_test.py
+++ b/tests/mypy_typing_test.py
@@ -1,0 +1,29 @@
+from typing import AsyncIterable, Type
+from lahja import (
+    BaseEvent,
+    BaseRequestResponseEvent,
+    Endpoint,
+)
+
+
+class Event(BaseEvent):
+    pass
+
+
+class RequestEvent(BaseRequestResponseEvent[Event]):
+    @staticmethod
+    def expected_response_type() -> Type[Event]:
+        return Event
+
+
+async def verify_wait_for_type(endpoint: Endpoint) -> Event:
+    return await endpoint.wait_for(Event)
+
+
+async def verify_stream_type(endpoint: Endpoint) -> AsyncIterable[Event]:
+    async for event in endpoint.stream(Event):
+        yield event
+
+
+async def verify_request_response_type(endpoint: Endpoint) -> Event:
+    return await endpoint.request(RequestEvent())

--- a/tox.ini
+++ b/tox.ini
@@ -72,6 +72,6 @@ basepython=python
 extras=lint
 commands=
     mypy lahja --ignore-missing-imports --strict
-    mypy {toxinidir}/tests/core --follow-imports=silent --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics
+    mypy --ignore-missing-imports --strict {toxinidir}/tests/mypy_typing_test.py
     flake8 {toxinidir}/lahja {toxinidir}/tests
     isort --recursive --check-only --diff {toxinidir}/lahja {toxinidir}/tests


### PR DESCRIPTION
fixes #52 

## What was wrong?

`trio` specifies `mypy` as a dependency and it requires a newer version than `lahja` uses.

## How was it fixed?

Updated `mypy` to latest and fixed type hints.  Also went ahead and addressed #52 

#### Cute Animal Picture

![2eabd7eb42d2b7e4baced9e41b698168](https://user-images.githubusercontent.com/824194/57490710-58eb4880-7277-11e9-92ed-49b72d7bd656.jpg)

