### PR TITLE
Set event loop in Endpoint.run if not already set

### DIFF
--- a/lahja/endpoint.py
+++ b/lahja/endpoint.py
@@ -376,7 +376,9 @@ class Endpoint(BaseEndpoint):
         self.ipc_path.unlink()
 
     @asynccontextmanager  # type: ignore
-    async def run(self) -> AsyncIterable['Endpoint']:
+    async def run(self) -> AsyncIterable['Endpoint']:  # type: ignore
+        if not self._loop:
+            self._loop = asyncio.get_event_loop()
         try:
             yield self
         finally:


### PR DESCRIPTION
## What was wrong?

The `Endpoint.run` method should set the event loop on the endpoint upon entry.

## How was it fixed?

Check if the `self._loop` is unset and set it if it is.

#### Cute Animal Picture

![5951153_f520](https://user-images.githubusercontent.com/824194/57715179-556b0f00-7633-11e9-87ab-8c9c057d2662.jpg)

