### PR TITLE
setup.py linting cleanup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,12 +34,11 @@ extras_require = {
     ]
 }
 
-extras_require['dev'] = (
-    extras_require['dev'] +
-    extras_require['test'] +
-    extras_require['lint'] +
-    extras_require['doc']
-)
+
+extras_require['dev'].extend(extras_require['test'])
+extras_require['dev'].extend(extras_require['lint'])
+extras_require['dev'].extend(extras_require['doc'])
+
 
 setup(
     name='lahja',


### PR DESCRIPTION
## What was wrong?

The `setup.py` file format caused linting errors in my editor.

## How was it fixed?

Changed from using line broken list addition to use `list.extend` to build the `[dev]` install requirements.

#### Cute Animal Picture

![Goat+Farming+in+Nigeria](https://user-images.githubusercontent.com/824194/57715391-e215cd00-7633-11e9-80cc-56d2fe4d6956.jpg)

