### PR TITLE
Namespace and isolate the asyncio tests in tox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,30 +63,30 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: lint
-  py36-core:
+  py36-core-asyncio:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
-          TOXENV: py36-core
-  py37-core:
+          TOXENV: py36-core-asyncio
+  py37-core-asyncio:
     <<: *common
     docker:
       - image: circleci/python:3.7
         environment:
-          TOXENV: py37-core
-  py36-snappy-core:
+          TOXENV: py37-core-asyncio
+  py36-snappy-core-asyncio:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
-          TOXENV: py36-snappy-core
-  py37-snappy-core:
+          TOXENV: py36-snappy-core-asyncio
+  py37-snappy-core-asyncio:
     <<: *common
     docker:
       - image: circleci/python:3.7
         environment:
-          TOXENV: py37-snappy-core
+          TOXENV: py37-snappy-core-asyncio
 workflows:
   version: 2
   test:
@@ -95,7 +95,7 @@ workflows:
       - snappy-benchmark
       - doctest
       - lint
-      - py36-core
-      - py37-core
-      - py36-snappy-core
-      - py37-snappy-core
+      - py36-core-asyncio
+      - py37-core-asyncio
+      - py36-snappy-core-asyncio
+      - py37-snappy-core-asyncio

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,11 @@ extras_require = {
     'test': [
         "cytoolz>=0.9.0,<1.0.0",
         "pytest==4.0.2",
-        "pytest-asyncio==0.9.0",
         "pytest-xdist==1.25.0",
         "tox>=2.9.1,<3",
+    ],
+    'test-asyncio': [
+        "pytest-asyncio==0.9.0",
     ],
     'lint': [
         "black==19.3b",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{36,37}-core
-    py{36,37}-snappy-core
+    py{36,37}-core-{asyncio}
+    py{36,37}-snappy-core-{asyncio}
     lint
     doctest
 
@@ -22,7 +22,7 @@ ignore=
 [testenv]
 usedevelop=True
 commands=
-    core: pytest {posargs:tests/core}
+    asyncio: pytest {posargs:tests/core/asyncio}
     doctest: make -C {toxinidir}/docs doctest
 basepython =
     doctest: python
@@ -30,6 +30,7 @@ basepython =
     py37: python3.7
 extras=
     test
+    asyncio: test-asyncio
     doctest: doc
     py36-snappy: snappy
     py37-snappy: snappy


### PR DESCRIPTION
## What was wrong?

`pytest-asyncio` does not play nicely with other asyncio frameworks as it tries to run **any** fixture that is a coroutine which causes `trio` based fixtures to error.

## How was it fixed?

Namespace and isolate the `asyncio` tests.

#### Cute Animal Picture

![mini-donkey](https://user-images.githubusercontent.com/824194/58042278-7af68d80-7af7-11e9-8e3c-03729c4989f7.jpeg)

