### PR TITLE
Simple performance improvements

### DIFF
--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -107,7 +107,6 @@ class Connection:
         return cls(reader, writer)
 
     async def send_message(self, message: Msg) -> None:
-        assert isinstance(message, Message)
         pickled = pickle.dumps(message)
         size = len(pickled)
 
@@ -129,8 +128,7 @@ class Connection:
             raw_size = await self.reader.readexactly(SIZE_MARKER_LENGTH)
             size = int.from_bytes(raw_size, "little")
             message = await self.reader.readexactly(size)
-            obj = pickle.loads(message)
-            assert isinstance(obj, Message)
+            obj = cast(Message, pickle.loads(message))
             return obj
         except (asyncio.IncompleteReadError, BrokenPipeError, ConnectionResetError):
             raise RemoteDisconnected()

--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -111,8 +111,7 @@ class Connection:
         size = len(pickled)
 
         try:
-            self.writer.write(size.to_bytes(SIZE_MARKER_LENGTH, "little"))
-            self.writer.write(pickled)
+            self.writer.write(size.to_bytes(SIZE_MARKER_LENGTH, "little") + pickled)
             async with self._drain_lock:
                 # Use a lock to serialize drain() calls. Circumvents this bug:
                 # https://bugs.python.org/issue29930


### PR DESCRIPTION
## What was wrong?

Some simple performance gains to be reaped.

## How was it fixed?

Removed the assert statements and combined the socket sending to be a single send.

Benchmarked as being about 17% faster.  The majority of this comes from reducing the number of socket sends with a small independent boost coming from removal of the `assert/isinstance` check.

Benchmarked using:

```
$ python ./scripts/perf_benchmark.py --num-processes 10 --num-events 10000
```

```
                                                                    +++ASYNCIO+++
                                                                    +++Globals+++
|Consumer processes |   Total time   | Total aggegated time  | Propagated events  |Received events | Propagated EPS |  Received EPS  |
|        10         |    2.74184     |       24.27840        |       10000        |     100000     |    3647.186    |   36471.863    |
                                                                +++Process Details+++
|      Process      |Processed Events|   First sent   | Last received  |    Fastest     |    Slowest     |      AVG       | Total duration | Total aggregated time |
|    consumer_2     |     10000      |  18:09:52.889  |  18:09:55.517  |    0.00023     |    0.00249     |    0.00032     |    2.62767     |        3.22462        |
|    consumer_3     |     10000      |  18:09:52.889  |  18:09:55.516  |    0.00009     |    0.00222     |    0.00014     |    2.62753     |        1.43092        |
|    consumer_1     |     10000      |  18:09:52.889  |  18:09:55.516  |    0.00020     |    0.00219     |    0.00027     |    2.62764     |        2.70120        |
|    consumer_6     |     10000      |  18:09:52.889  |  18:09:55.516  |    0.00012     |    0.00228     |    0.00019     |    2.62756     |        1.87550        |
|    consumer_4     |     10000      |  18:09:52.889  |  18:09:55.516  |    0.00018     |    0.00245     |    0.00025     |    2.62758     |        2.53837        |
|    consumer_5     |     10000      |  18:09:52.889  |  18:09:55.516  |    0.00016     |    0.00243     |    0.00023     |    2.62759     |        2.30942        |
|    consumer_0     |     10000      |  18:09:52.889  |  18:09:55.517  |    0.00021     |    0.00246     |    0.00030     |    2.62766     |        2.95039        |
|    consumer_7     |     10000      |  18:09:52.889  |  18:09:55.517  |    0.00024     |    0.00243     |    0.00035     |    2.62771     |        3.45712        |
|    consumer_8     |     10000      |  18:09:52.889  |  18:09:55.516  |    0.00011     |    0.00196     |    0.00017     |    2.62755     |        1.69412        |
|    consumer_9     |     10000      |  18:09:52.889  |  18:09:55.516  |    0.00014     |    0.00191     |    0.00021     |    2.62759     |        2.09673        |

                                                                    +++ASYNCIO+++
                                                                    +++Globals+++
|Consumer processes |   Total time   | Total aggegated time  | Propagated events  |Received events | Propagated EPS |  Received EPS  |
|        10         |    2.68537     |       23.40630        |       10000        |     100000     |    3723.888    |   37238.880    |
                                                                +++Process Details+++
|      Process      |Processed Events|   First sent   | Last received  |    Fastest     |    Slowest     |      AVG       | Total duration | Total aggregated time |
|    consumer_8     |     10000      |  18:10:01.872  |  18:10:04.429  |    0.00021     |    0.00246     |    0.00029     |    2.55756     |        2.85174        |
|    consumer_5     |     10000      |  18:10:01.872  |  18:10:04.429  |    0.00010     |    0.00243     |    0.00016     |    2.55742     |        1.62102        |
|    consumer_3     |     10000      |  18:10:01.872  |  18:10:04.429  |    0.00009     |    0.00225     |    0.00014     |    2.55736     |        1.37141        |
|    consumer_4     |     10000      |  18:10:01.872  |  18:10:04.429  |    0.00012     |    0.00195     |    0.00018     |    2.55741     |        1.80014        |
|    consumer_1     |     10000      |  18:10:01.872  |  18:10:04.429  |    0.00014     |    0.00243     |    0.00020     |    2.55743     |        2.00939        |
|    consumer_0     |     10000      |  18:10:01.872  |  18:10:04.429  |    0.00016     |    0.00235     |    0.00022     |    2.55746     |        2.20437        |
|    consumer_7     |     10000      |  18:10:01.872  |  18:10:04.429  |    0.00020     |    0.00250     |    0.00027     |    2.55755     |        2.65918        |
|    consumer_2     |     10000      |  18:10:01.872  |  18:10:04.429  |    0.00018     |    0.00251     |    0.00024     |    2.55750     |        2.43781        |
|    consumer_6     |     10000      |  18:10:01.872  |  18:10:04.429  |    0.00023     |    0.00258     |    0.00031     |    2.55759     |        3.10038        |
|    consumer_9     |     10000      |  18:10:01.872  |  18:10:04.429  |    0.00024     |    0.00253     |    0.00034     |    2.55762     |        3.35086        |
```

Before: on `master`

```
                                                                    +++ASYNCIO+++
                                                                    +++Globals+++
|Consumer processes |   Total time   | Total aggegated time  | Propagated events  |Received events | Propagated EPS |  Received EPS  |
|        10         |    3.12736     |       26.17552        |       10000        |     100000     |    3197.580    |   31975.802    |
                                                                +++Process Details+++
|      Process      |Processed Events|   First sent   | Last received  |    Fastest     |    Slowest     |      AVG       | Total duration | Total aggregated time |
|    consumer_8     |     10000      |  18:10:09.125  |  18:10:12.144  |    0.00011     |    0.00211     |    0.00017     |    3.01858     |        1.71052        |
|    consumer_6     |     10000      |  18:10:09.125  |  18:10:12.144  |    0.00013     |    0.00126     |    0.00019     |    3.01863     |        1.94907        |
|    consumer_9     |     10000      |  18:10:09.125  |  18:10:12.144  |    0.00015     |    0.00222     |    0.00022     |    3.01863     |        2.16980        |
|    consumer_4     |     10000      |  18:10:09.125  |  18:10:12.144  |    0.00020     |    0.00203     |    0.00027     |    3.01869     |        2.73728        |
|    consumer_3     |     10000      |  18:10:09.125  |  18:10:12.144  |    0.00009     |    0.00117     |    0.00014     |    3.01856     |        1.38968        |
|    consumer_0     |     10000      |  18:10:09.125  |  18:10:12.144  |    0.00024     |    0.00254     |    0.00033     |    3.01878     |        3.31586        |
|    consumer_7     |     10000      |  18:10:09.125  |  18:10:12.144  |    0.00027     |    0.00230     |    0.00038     |    3.01884     |        3.84451        |
|    consumer_1     |     10000      |  18:10:09.125  |  18:10:12.144  |    0.00022     |    0.00234     |    0.00030     |    3.01877     |        2.99963        |
|    consumer_5     |     10000      |  18:10:09.125  |  18:10:12.144  |    0.00017     |    0.00233     |    0.00025     |    3.01869     |        2.47736        |
|    consumer_2     |     10000      |  18:10:09.125  |  18:10:12.144  |    0.00025     |    0.00294     |    0.00036     |    3.01883     |        3.58180        |

                                                                    +++ASYNCIO+++
                                                                    +++Globals+++
|Consumer processes |   Total time   | Total aggegated time  | Propagated events  |Received events | Propagated EPS |  Received EPS  |
|        10         |    3.20089     |       27.03218        |       10000        |     100000     |    3124.132    |   31241.322    |
                                                                +++Process Details+++
|      Process      |Processed Events|   First sent   | Last received  |    Fastest     |    Slowest     |      AVG       | Total duration | Total aggregated time |
|    consumer_5     |     10000      |  18:10:14.488  |  18:10:17.561  |    0.00013     |    0.00230     |    0.00021     |    3.07327     |        2.07678        |
|    consumer_1     |     10000      |  18:10:14.488  |  18:10:17.561  |    0.00018     |    0.00236     |    0.00026     |    3.07336     |        2.57830        |
|    consumer_4     |     10000      |  18:10:14.488  |  18:10:17.561  |    0.00015     |    0.00195     |    0.00023     |    3.07329     |        2.30362        |
|    consumer_6     |     10000      |  18:10:14.488  |  18:10:17.561  |    0.00011     |    0.00219     |    0.00018     |    3.07323     |        1.81096        |
|    consumer_3     |     10000      |  18:10:14.488  |  18:10:17.561  |    0.00009     |    0.00219     |    0.00015     |    3.07325     |        1.50355        |
|    consumer_0     |     10000      |  18:10:14.488  |  18:10:17.561  |    0.00020     |    0.00241     |    0.00028     |    3.07336     |        2.79298        |
|    consumer_7     |     10000      |  18:10:14.488  |  18:10:17.561  |    0.00024     |    0.00234     |    0.00034     |    3.07344     |        3.36290        |
|    consumer_2     |     10000      |  18:10:14.488  |  18:10:17.561  |    0.00022     |    0.00242     |    0.00031     |    3.07339     |        3.08278        |
|    consumer_9     |     10000      |  18:10:14.488  |  18:10:17.561  |    0.00028     |    0.00249     |    0.00039     |    3.07354     |        3.90406        |
|    consumer_8     |     10000      |  18:10:14.488  |  18:10:17.561  |    0.00026     |    0.00250     |    0.00036     |    3.07346     |        3.61623        |
```

#### Cute Animal Picture

![miniature-horse](https://user-images.githubusercontent.com/824194/58042867-01f83580-7af9-11e9-9013-19a6cd33a23d.jpg)

