### PR TITLE
Update `EndpointAPI.subscribe` to be async and to accept coroutines

### DIFF
--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -1,6 +1,8 @@
 import asyncio
 from asyncio import StreamReader, StreamWriter
+from collections import defaultdict
 import functools
+import inspect
 import itertools
 import logging
 from pathlib import Path
@@ -12,6 +14,7 @@ from typing import (  # noqa: F401
     AsyncGenerator,
     AsyncIterable,
     AsyncIterator,
+    Awaitable,
     Callable,
     Dict,
     List,
@@ -231,6 +234,10 @@ class OutboundConnection:
 TFunc = TypeVar("TFunc", bound=Callable[..., Any])
 
 
+SubscriptionAsyncHandler = Callable[[BaseEvent], Awaitable[Any]]
+SubscriptionSyncHandler = Callable[[BaseEvent], Any]
+
+
 class AsyncioEndpoint(BaseEndpoint):
     """
     The :class:`~lahja.asyncio.AsyncioEndpoint` enables communication between different processes
@@ -251,7 +258,14 @@ class AsyncioEndpoint(BaseEndpoint):
         self._inbound_connections: Set[InboundConnection] = set()
 
         self._futures: Dict[Optional[str], "asyncio.Future[BaseEvent]"] = {}
-        self._handler: Dict[Type[BaseEvent], List[Callable[[BaseEvent], Any]]] = {}
+        # we intentionally store the handlers separately so that we don't have
+        # to do the `inspect.iscoroutine` at runtime while processing events.
+        self._async_handler: Dict[
+            Type[BaseEvent], List[SubscriptionAsyncHandler]
+        ] = defaultdict(list)
+        self._sync_handler: Dict[
+            Type[BaseEvent], List[SubscriptionSyncHandler]
+        ] = defaultdict(list)
         self._queues: Dict[Type[BaseEvent], List["asyncio.Queue[BaseEvent]"]] = {}
 
         self._endpoint_tasks: Set["asyncio.Future[Any]"] = set()
@@ -359,7 +373,11 @@ class AsyncioEndpoint(BaseEndpoint):
         """
         Return the set of events this Endpoint is currently listening for
         """
-        return set(self._handler.keys()) | set(self._queues.keys())
+        return (
+            set(self._sync_handler.keys())
+            .union(self._async_handler.keys())
+            .union(self._queues.keys())
+        )
 
     async def _notify_subscriptions_changed(self) -> None:
         """
@@ -451,7 +469,7 @@ class AsyncioEndpoint(BaseEndpoint):
                 raise
             try:
                 event = self._decompress_event(item)
-                self._process_item(event, config)
+                await self._process_item(event, config)
             except Exception:
                 traceback.print_exc()
 
@@ -506,7 +524,9 @@ class AsyncioEndpoint(BaseEndpoint):
     def is_connected_to(self, endpoint_name: str) -> bool:
         return endpoint_name in self._outbound_connections
 
-    def _process_item(self, item: BaseEvent, config: Optional[BroadcastConfig]) -> None:
+    async def _process_item(
+        self, item: BaseEvent, config: Optional[BroadcastConfig]
+    ) -> None:
         event_type = type(item)
 
         if config is not None and config.filter_event_id in self._futures:
@@ -519,9 +539,14 @@ class AsyncioEndpoint(BaseEndpoint):
             for queue in self._queues[event_type]:
                 queue.put_nowait(item)
 
-        if event_type in self._handler:
-            for handler in self._handler[event_type]:
+        if event_type in self._sync_handler:
+            for handler in self._sync_handler[event_type]:
                 handler(item)
+
+        if event_type in self._async_handler:
+            await asyncio.gather(
+                *(handler(item) for handler in self._async_handler[event_type])
+            )
 
     def stop_server(self) -> None:
         if not self.is_serving:
@@ -591,7 +616,7 @@ class AsyncioEndpoint(BaseEndpoint):
         if config is not None and config.internal:
             # Internal events simply bypass going over the event bus and are
             # processed immediately.
-            self._process_item(item, config)
+            await self._process_item(item, config)
             return
 
         # Broadcast to every connected Endpoint that is allowed to receive the event
@@ -671,34 +696,56 @@ class AsyncioEndpoint(BaseEndpoint):
         except asyncio.CancelledError:
             self._futures.pop(id, None)
 
-    def subscribe(
+    def _remove_async_subscription(
+        self, event_type: Type[BaseEvent], handler_fn: SubscriptionAsyncHandler
+    ) -> None:
+        self._async_handler[event_type].remove(handler_fn)
+        if not self._async_handler[event_type]:
+            self._async_handler.pop(event_type)
+        # this is asynchronous because that's a better user experience than making
+        # the user `await subscription.remove()`. This means this Endpoint will keep
+        # getting events for a little while after it stops listening for them but
+        # that's a performance problem, not a correctness problem.
+        asyncio.ensure_future(self._notify_subscriptions_changed())
+
+    def _remove_sync_subscription(
+        self, event_type: Type[BaseEvent], handler_fn: SubscriptionSyncHandler
+    ) -> None:
+        self._sync_handler[event_type].remove(handler_fn)
+        if not self._sync_handler[event_type]:
+            self._sync_handler.pop(event_type)
+        # this is asynchronous because that's a better user experience than making
+        # the user `await subscription.remove()`. This means this Endpoint will keep
+        # getting events for a little while after it stops listening for them but
+        # that's a performance problem, not a correctness problem.
+        asyncio.ensure_future(self._notify_subscriptions_changed())
+
+    async def subscribe(
         self,
         event_type: Type[TSubscribeEvent],
-        handler: Callable[[TSubscribeEvent], None],
+        handler: Callable[[TSubscribeEvent], Union[Any, Awaitable[Any]]],
     ) -> Subscription:
         """
         Subscribe to receive updates for any event that matches the specified event type.
         A handler is passed as a second argument an :class:`~lahja.common.Subscription` is returned
         to unsubscribe from the event if needed.
         """
-        if event_type not in self._handler:
-            self._handler[event_type] = []
+        if inspect.iscoroutine(handler):
+            casted_handler = cast(SubscriptionAsyncHandler, handler)
+            self._async_handler[event_type].append(casted_handler)
+            unsubscribe_fn = functools.partial(
+                self._remove_async_subscription, event_type, casted_handler
+            )
+        else:
+            casted_handler = cast(SubscriptionSyncHandler, handler)
+            self._sync_handler[event_type].append(casted_handler)
+            unsubscribe_fn = functools.partial(
+                self._remove_sync_subscription, event_type, casted_handler
+            )
 
-        casted_handler = cast(Callable[[BaseEvent], Any], handler)
+        await self._notify_subscriptions_changed()
 
-        self._handler[event_type].append(casted_handler)
-        # It's probably better to make subscribe() async and await this coro
-        asyncio.ensure_future(self._notify_subscriptions_changed())
-
-        def remove() -> None:
-            self._handler[event_type].remove(casted_handler)
-            # this is asynchronous because that's a better user experience than making
-            # the user `await subscription.remove()`. This means this Endpoint will keep
-            # getting events for a little while after it stops listening for them but
-            # that's a performance problem, not a correctness problem.
-            asyncio.ensure_future(self._notify_subscriptions_changed())
-
-        return Subscription(remove)
+        return Subscription(unsubscribe_fn)
 
     async def stream(
         self, event_type: Type[TStreamEvent], num_events: Optional[int] = None
@@ -733,4 +780,6 @@ class AsyncioEndpoint(BaseEndpoint):
                     break
         finally:
             self._queues[event_type].remove(casted_queue)
+            if not self._queues[event_type]:
+                del self._queues[event_type]
             await self._notify_subscriptions_changed()

--- a/lahja/base.py
+++ b/lahja/base.py
@@ -5,6 +5,7 @@ from typing import (  # noqa: F401
     Any,
     AsyncContextManager,
     AsyncGenerator,
+    Awaitable,
     Callable,
     Dict,
     Iterable,
@@ -55,6 +56,8 @@ class EndpointAPI(ABC):
     The :class:`~lahja.endpoint.Endpoint` enables communication between different processes
     as well as within a single process via various event-driven APIs.
     """
+
+    __slots__ = ("name",)
 
     name: str
 
@@ -184,10 +187,10 @@ class EndpointAPI(ABC):
         ...
 
     @abstractmethod
-    def subscribe(
+    async def subscribe(
         self,
         event_type: Type[TSubscribeEvent],
-        handler: Callable[[TSubscribeEvent], None],
+        handler: Callable[[TSubscribeEvent], Union[Any, Awaitable[Any]]],
     ) -> Subscription:
         """
         Subscribe to receive updates for any event that matches the specified event type.

--- a/tests/core/asyncio/test_asyncio_subscriptions_api.py
+++ b/tests/core/asyncio/test_asyncio_subscriptions_api.py
@@ -1,0 +1,223 @@
+import asyncio
+
+import pytest
+
+from lahja import AsyncioEndpoint, BaseEvent, ConnectionConfig
+
+
+class StreamEvent(BaseEvent):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_asyncio_stream_api_updates_subscriptions(pair_of_endpoints):
+    subscriber, other = pair_of_endpoints
+    remote = other._outbound_connections[subscriber.name]
+
+    assert StreamEvent not in remote.subscribed_messages
+    assert StreamEvent not in subscriber.subscribed_events
+
+    stream_agen = subscriber.stream(StreamEvent, num_events=2)
+    # start the generator in the background and give it a moment to start (so
+    # that the subscription can get setup and propogated)
+    fut = asyncio.ensure_future(stream_agen.asend(None))
+    await asyncio.sleep(0.01)
+
+    # broadcast the first event and grab and validate the first streamed
+    # element.
+    await other.broadcast(StreamEvent())
+    event_1 = await fut
+    assert isinstance(event_1, StreamEvent)
+
+    # Now that we are within the stream, verify that the subscription is active
+    # on the remote
+    assert StreamEvent in remote.subscribed_messages
+    assert StreamEvent in subscriber.subscribed_events
+
+    # Broadcast and receive the second event, finishing the stream and
+    # consequently the subscription
+    await other.broadcast(StreamEvent())
+    event_2 = await stream_agen.asend(None)
+    assert isinstance(event_2, StreamEvent)
+    await stream_agen.aclose()
+    # give the subscription removal time to propagate.
+    await asyncio.sleep(0.01)
+
+    # Ensure the event is no longer in the subscriptions.
+    assert StreamEvent not in remote.subscribed_messages
+    assert StreamEvent not in subscriber.subscribed_events
+
+
+@pytest.mark.asyncio
+async def test_asyncio_wait_for_updates_subscriptions(pair_of_endpoints):
+    subscriber, other = pair_of_endpoints
+    remote = other._outbound_connections[subscriber.name]
+
+    assert StreamEvent not in remote.subscribed_messages
+    assert StreamEvent not in subscriber.subscribed_events
+
+    # trigger a `wait_for` call to run in the background and give it a moment
+    # to spin up.
+    task = asyncio.ensure_future(subscriber.wait_for(StreamEvent))
+    await asyncio.sleep(0.01)
+
+    # Now that we are within the wait_for, verify that the subscription is active
+    # on the remote
+    assert StreamEvent in remote.subscribed_messages
+    assert StreamEvent in subscriber.subscribed_events
+
+    # Broadcast and receive the second event, finishing the stream and
+    # consequently the subscription
+    await other.broadcast(StreamEvent())
+    event = await task
+    assert isinstance(event, StreamEvent)
+    # give the subscription removal time to propagate.
+    await asyncio.sleep(0.01)
+
+    # Ensure the event is no longer in the subscriptions.
+    assert StreamEvent not in remote.subscribed_messages
+    assert StreamEvent not in subscriber.subscribed_events
+
+
+class InheretedStreamEvent(StreamEvent):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_asyncio_subscription_api_does_not_match_inherited_classes(
+    pair_of_endpoints
+):
+    subscriber, other = pair_of_endpoints
+    remote = other._outbound_connections[subscriber.name]
+
+    assert StreamEvent not in remote.subscribed_messages
+    assert StreamEvent not in subscriber.subscribed_events
+
+    # trigger a `wait_for` call to run in the background and give it a moment
+    # to spin up.
+    task = asyncio.ensure_future(subscriber.wait_for(StreamEvent))
+    await asyncio.sleep(0.01)
+
+    # Now that we are within the wait_for, verify that the subscription is active
+    # on the remote
+    assert StreamEvent in remote.subscribed_messages
+    assert StreamEvent in subscriber.subscribed_events
+
+    # Broadcast two of the inherited events and then the correct event.
+    await other.broadcast(InheretedStreamEvent())
+    await other.broadcast(InheretedStreamEvent())
+    await other.broadcast(StreamEvent())
+
+    # wait for a received event, finishing the stream and
+    # consequently the subscription
+    event = await task
+    assert isinstance(event, StreamEvent)
+
+
+class SubscribeEvent(BaseEvent):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_asyncio_subscribe_updates_subscriptions(pair_of_endpoints):
+    subscriber, other = pair_of_endpoints
+    remote = other._outbound_connections[subscriber.name]
+
+    assert SubscribeEvent not in remote.subscribed_messages
+    assert SubscribeEvent not in subscriber.subscribed_events
+
+    received_events = []
+
+    # trigger a `wait_for` call to run in the background and give it a moment
+    # to spin up.
+    subscription = await subscriber.subscribe(SubscribeEvent, received_events.append)
+    await asyncio.sleep(0.01)
+
+    # Now that we are within the wait_for, verify that the subscription is active
+    # on the remote
+    assert SubscribeEvent in remote.subscribed_messages
+    assert SubscribeEvent in subscriber.subscribed_events
+
+    # Broadcast and receive the second event, finishing the stream and
+    # consequently the subscription
+    await other.broadcast(SubscribeEvent())
+    # give time for propagation
+    await asyncio.sleep(0.01)
+    assert len(received_events) == 1
+    event = received_events[0]
+    assert isinstance(event, SubscribeEvent)
+
+    # Ensure the event is still in the subscriptions.
+    assert SubscribeEvent in remote.subscribed_messages
+    assert SubscribeEvent in subscriber.subscribed_events
+
+    subscription.unsubscribe()
+    # give the subscription removal time to propagate.
+    await asyncio.sleep(0.01)
+
+    # Ensure the event is no longer in the subscriptions.
+    assert SubscribeEvent not in remote.subscribed_messages
+    assert SubscribeEvent not in subscriber.subscribed_events
+
+
+@pytest.fixture
+async def client_with_three_connections(ipc_base_path):
+    config_a = ConnectionConfig.from_name("server-a", base_path=ipc_base_path)
+    config_b = ConnectionConfig.from_name("server-b", base_path=ipc_base_path)
+    config_c = ConnectionConfig.from_name("server-c", base_path=ipc_base_path)
+
+    async with AsyncioEndpoint.serve(config_a) as server_a:
+        async with AsyncioEndpoint.serve(config_b) as server_b:
+            async with AsyncioEndpoint.serve(config_c) as server_c:
+                async with AsyncioEndpoint("client").run() as client:
+                    await client.connect_to_endpoint(config_a)
+                    await client.connect_to_endpoint(config_b)
+                    await client.connect_to_endpoint(config_c)
+
+                    yield client, server_a, server_b, server_c
+
+
+class WaitSubscription(BaseEvent):
+    pass
+
+
+def noop(event):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_asyncio_wait_until_any_connection_subscribed_to(
+    client_with_three_connections
+):
+    client, server_a, server_b, server_c = client_with_three_connections
+
+    asyncio.ensure_future(server_a.subscribe(WaitSubscription, noop))
+
+    await asyncio.wait_for(
+        client.wait_until_any_connection_subscribed_to(WaitSubscription), timeout=0.1
+    )
+
+
+@pytest.mark.asyncio
+async def test_asyncio_wait_until_all_connection_subscribed_to(
+    client_with_three_connections
+):
+    client, server_a, server_b, server_c = client_with_three_connections
+
+    got_subscription = asyncio.Event()
+
+    async def do_wait_subscriptions():
+        await client.wait_until_all_connections_subscribed_to(WaitSubscription)
+        got_subscription.set()
+
+    asyncio.ensure_future(do_wait_subscriptions())
+
+    assert len(client._outbound_connections) == 3
+
+    await server_c.subscribe(WaitSubscription, noop)
+    assert got_subscription.is_set() is False
+    await server_a.subscribe(WaitSubscription, noop)
+    assert got_subscription.is_set() is False
+    await server_b.subscribe(WaitSubscription, noop)
+    await asyncio.sleep(0.01)
+    assert got_subscription.is_set() is True

--- a/tests/core/asyncio/test_broadcast_config.py
+++ b/tests/core/asyncio/test_broadcast_config.py
@@ -10,11 +10,11 @@ async def test_broadcasts_to_all_endpoints(triplet_of_endpoints):
 
     tracker = Tracker()
 
-    endpoint1.subscribe(
+    await endpoint1.subscribe(
         DummyRequestPair, tracker.track_and_broadcast_dummy(1, endpoint1)
     )
 
-    endpoint2.subscribe(
+    await endpoint2.subscribe(
         DummyRequestPair, tracker.track_and_broadcast_dummy(2, endpoint2)
     )
 
@@ -40,11 +40,11 @@ async def test_broadcasts_to_specific_endpoint(triplet_of_endpoints):
 
     tracker = Tracker()
 
-    endpoint1.subscribe(
+    await endpoint1.subscribe(
         DummyRequestPair, tracker.track_and_broadcast_dummy(1, endpoint1)
     )
 
-    endpoint2.subscribe(
+    await endpoint2.subscribe(
         DummyRequestPair, tracker.track_and_broadcast_dummy(2, endpoint1)
     )
 


### PR DESCRIPTION
fixes #65 

## What was wrong?

The `EndpointAPI.subscribe` API was defined as synchronous, but has an internal need to perform an asynchronous action to update the endpoint subscriptions.


## How was it fixed?

Updated the API to be async as well as expanding the API to allow the *handler* to be a coroutine.

#### Cute Animal Picture

![ZippyCowboy05-01-2013](https://user-images.githubusercontent.com/824194/58043103-9498d480-7af9-11e9-9e12-41e4bdbf1d36.jpg)
