### PR TITLE
Remove TRANSPARENT_EVENT

### DIFF
--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -32,7 +32,6 @@ from async_generator import asynccontextmanager
 from lahja._snappy import check_has_snappy_support
 from lahja.base import BaseEndpoint, TResponse, TStreamEvent, TSubscribeEvent
 from lahja.common import (
-    TRANSPARENT_EVENT,
     BaseEvent,
     BaseRequestResponseEvent,
     Broadcast,
@@ -535,9 +534,6 @@ class AsyncioEndpoint(BaseEndpoint):
         return endpoint_name in self._outbound_connections
 
     def _process_item(self, item: BaseEvent, config: Optional[BroadcastConfig]) -> None:
-        if item is TRANSPARENT_EVENT:
-            return
-
         event_type = type(item)
 
         if config is not None and config.filter_event_id in self._futures:
@@ -562,8 +558,6 @@ class AsyncioEndpoint(BaseEndpoint):
             return
 
         self._running = False
-        self._receiving_queue.put_nowait((TRANSPARENT_EVENT, None))
-        self._internal_queue.put_nowait((TRANSPARENT_EVENT, None))
         for task in self._child_tasks:
             task.cancel()
         self._server.close()

--- a/lahja/common.py
+++ b/lahja/common.py
@@ -76,19 +76,6 @@ class BaseRequestResponseEvent(ABC, BaseEvent, Generic[TResponse]):
         raise NotImplementedError("Must be implemented by subsclasses")
 
 
-class TransparentEvent(BaseEvent):
-    """
-    This event is used to create artificial activity so that code that
-    blocks on a :meth:`~multiprocessing.queues.Queue.get` unblocks and
-    gets a chance to revalidate if it should continue to block for reading.
-    """
-
-    pass
-
-
-TRANSPARENT_EVENT = TransparentEvent()
-
-
 class ConnectionConfig(NamedTuple):
     """
     Configuration class needed to establish :class:`~lahja.endpoint.Endpoint` connections.


### PR DESCRIPTION
## What was wrong?

The use of `TRANSPARENT_EVENT` was a legacy carry-over from the multiprocessing days.  It isn't needed anymore.

## How was it fixed?

Removed it.

#### Cute Animal Picture

![680f333774468fe323021503f8639c58](https://user-images.githubusercontent.com/824194/58107204-9bc9ec00-7ba6-11e9-8e2d-0a61f0e34197.png)

