### PR TITLE
More flexible wait APIs

### DIFF
--- a/lahja/common.py
+++ b/lahja/common.py
@@ -16,7 +16,7 @@ from typing import (  # noqa: F401
 from lahja.exceptions import BindError
 
 if TYPE_CHECKING:
-    from lahja.base import EndpointAPI
+    from lahja.base import EndpointAPI  # noqa: F401
 
 
 class Subscription:
@@ -89,6 +89,10 @@ class BaseRequestResponseEvent(ABC, BaseEvent, Generic[TResponse]):
         back to callsites that issued a `BaseRequestResponseEvent`
         """
         raise NotImplementedError("Must be implemented by subsclasses")
+
+
+class RemoteSubscriptionChanged(BaseEvent):
+    pass
 
 
 class ConnectionConfig(NamedTuple):

--- a/lahja/tools/benchmark/process.py
+++ b/lahja/tools/benchmark/process.py
@@ -57,7 +57,7 @@ class DriverProcess:
         conn_config = ConnectionConfig.from_name(DRIVER_ENDPOINT)
         async with config.backend.Endpoint.serve(conn_config) as event_bus:
             await event_bus.connect_to_endpoints(*config.connected_endpoints)
-            await event_bus.wait_until_all_connections_subscribed_to(PerfMeasureEvent)
+            await event_bus.wait_until_all_remotes_subscribed_to(PerfMeasureEvent)
 
             counter = itertools.count()
             payload = b"\x00" * config.payload_bytes
@@ -95,7 +95,7 @@ class ConsumerProcess:
             await event_bus.connect_to_endpoints(
                 ConnectionConfig.from_name(REPORTER_ENDPOINT)
             )
-            await event_bus.wait_until_all_connections_subscribed_to(TotalRecordedEvent)
+            await event_bus.wait_until_all_remotes_subscribed_to(TotalRecordedEvent)
 
             stats = LocalStatistic()
             events = event_bus.stream(PerfMeasureEvent, num_events=num_events)

--- a/tests/core/asyncio/test_asyncio_subscriptions_api.py
+++ b/tests/core/asyncio/test_asyncio_subscriptions_api.py
@@ -186,7 +186,7 @@ def noop(event):
 
 
 @pytest.mark.asyncio
-async def test_asyncio_wait_until_any_connection_subscribed_to(
+async def test_asyncio_wait_until_any_remote_subscribed_to(
     client_with_three_connections
 ):
     client, server_a, server_b, server_c = client_with_three_connections
@@ -194,7 +194,7 @@ async def test_asyncio_wait_until_any_connection_subscribed_to(
     asyncio.ensure_future(server_a.subscribe(WaitSubscription, noop))
 
     await asyncio.wait_for(
-        client.wait_until_any_connection_subscribed_to(WaitSubscription), timeout=0.1
+        client.wait_until_any_remote_subscribed_to(WaitSubscription), timeout=0.1
     )
 
 
@@ -207,7 +207,7 @@ async def test_asyncio_wait_until_all_connection_subscribed_to(
     got_subscription = asyncio.Event()
 
     async def do_wait_subscriptions():
-        await client.wait_until_all_connections_subscribed_to(WaitSubscription)
+        await client.wait_until_all_remotes_subscribed_to(WaitSubscription)
         got_subscription.set()
 
     asyncio.ensure_future(do_wait_subscriptions())

--- a/tests/core/asyncio/test_basics.py
+++ b/tests/core/asyncio/test_basics.py
@@ -33,8 +33,7 @@ async def test_request_response(endpoint, event_loop):
         await endpoint.broadcast(Response(req.value), req.broadcast_config())
 
     asyncio.ensure_future(do_serve_response())
-
-    await endpoint.wait_until_any_connection_subscribed_to(Request)
+    await endpoint.wait_until_any_remote_subscribed_to(Request)
 
     response = await endpoint.request(Request("test-request"))
     assert isinstance(response, Response)
@@ -63,7 +62,7 @@ async def test_response_must_match(endpoint):
 
     asyncio.ensure_future(do_serve_wrong_response())
 
-    await endpoint.wait_until_any_connection_subscribed_to(Request)
+    await endpoint.wait_until_any_remote_subscribed_to(Request)
 
     with pytest.raises(UnexpectedResponse):
         await endpoint.request(Request("test-wrong-response"))
@@ -85,7 +84,7 @@ async def test_stream_with_break(endpoint):
                 break
 
     asyncio.ensure_future(stream_response())
-    await endpoint.wait_until_any_connection_subscribed_to(DummyRequest)
+    await endpoint.wait_until_any_remote_subscribed_to(DummyRequest)
 
     # we broadcast one more item than what we consume and test for that
     for i in range(5):
@@ -110,7 +109,7 @@ async def test_stream_with_num_events(endpoint):
             stream_counter += 1
 
     asyncio.ensure_future(stream_response())
-    await endpoint.wait_until_any_connection_subscribed_to(DummyRequest)
+    await endpoint.wait_until_any_remote_subscribed_to(DummyRequest)
 
     # we broadcast one more item than what we consume and test for that
     for i in range(3):
@@ -145,7 +144,7 @@ async def test_stream_can_get_cancelled(endpoint):
 
     stream_coro = asyncio.ensure_future(stream_response())
     cancel_coro = asyncio.ensure_future(cancel_soon())
-    await endpoint.wait_until_any_connection_subscribed_to(DummyRequest)
+    await endpoint.wait_until_any_remote_subscribed_to(DummyRequest)
 
     for i in range(50):
         await endpoint.broadcast(DummyRequest())
@@ -174,7 +173,7 @@ async def test_stream_cancels_when_parent_task_is_cancelled(endpoint):
             await asyncio.sleep(0.01)
 
     task = asyncio.ensure_future(stream_response())
-    await endpoint.wait_until_any_connection_subscribed_to(DummyRequest)
+    await endpoint.wait_until_any_remote_subscribed_to(DummyRequest)
 
     async def cancel_soon():
         while True:
@@ -207,7 +206,7 @@ async def test_wait_for(endpoint):
         received = request
 
     asyncio.ensure_future(stream_response())
-    await endpoint.wait_until_any_connection_subscribed_to(DummyRequest)
+    await endpoint.wait_until_any_remote_subscribed_to(DummyRequest)
     await endpoint.broadcast(DummyRequest())
 
     await asyncio.sleep(0.01)
@@ -237,7 +236,7 @@ async def test_exceptions_dont_stop_processing(capsys, endpoint):
         the_set.remove(message.item)
 
     await endpoint.subscribe(RemoveItem, handle)
-    await endpoint.wait_until_any_connection_subscribed_to(RemoveItem)
+    await endpoint.wait_until_any_remote_subscribed_to(RemoveItem)
 
     # this call should work
     await endpoint.broadcast(RemoveItem(1))

--- a/tests/core/asyncio/test_broadcast_config.py
+++ b/tests/core/asyncio/test_broadcast_config.py
@@ -18,7 +18,7 @@ async def test_broadcasts_to_all_endpoints(triplet_of_endpoints):
         DummyRequestPair, tracker.track_and_broadcast_dummy(2, endpoint2)
     )
 
-    await endpoint3.wait_until_all_connections_subscribed_to(DummyRequestPair)
+    await endpoint3.wait_until_all_remotes_subscribed_to(DummyRequestPair)
 
     item = DummyRequestPair()
     response = await endpoint3.request(item)
@@ -48,7 +48,7 @@ async def test_broadcasts_to_specific_endpoint(triplet_of_endpoints):
         DummyRequestPair, tracker.track_and_broadcast_dummy(2, endpoint1)
     )
 
-    await endpoint3.wait_until_all_connections_subscribed_to(DummyRequestPair)
+    await endpoint3.wait_until_all_remotes_subscribed_to(DummyRequestPair)
 
     item = DummyRequestPair()
     response = await endpoint3.request(

--- a/tests/core/asyncio/test_internal.py
+++ b/tests/core/asyncio/test_internal.py
@@ -24,8 +24,8 @@ async def test_internal_propagation(pair_of_endpoints):
     will_not_finish = asyncio.ensure_future(do_wait_for(endpoint_b, got_by_endpoint_b))
 
     # give subscriptions time to update
-    await endpoint_a.wait_until_all_connections_subscribed_to(Internal)
-    await endpoint_b.wait_until_all_connections_subscribed_to(Internal)
+    await endpoint_a.wait_until_all_remotes_subscribed_to(Internal)
+    await endpoint_b.wait_until_all_remotes_subscribed_to(Internal)
 
     # now broadcast a few over the internal bus on `A`
     for _ in range(5):

--- a/tests/core/asyncio/test_subscription_wait_apis.py
+++ b/tests/core/asyncio/test_subscription_wait_apis.py
@@ -1,0 +1,90 @@
+import asyncio
+
+import pytest
+
+from helpers import DummyRequestPair, DummyResponse
+
+
+@pytest.mark.asyncio
+async def test_wait_until_any_subscribed(triplet_of_endpoints):
+    endpoint1, endpoint2, endpoint3 = triplet_of_endpoints
+
+    await endpoint1.subscribe(DummyRequestPair, lambda _: None)
+
+    await endpoint3.wait_until_any_remote_subscribed_to(DummyRequestPair)
+
+    subscriptions = endpoint3.get_connected_endpoints_and_subscriptions()
+
+    assert (endpoint1.name, {DummyRequestPair}) in subscriptions
+
+    assert endpoint3.is_remote_subscribed_to(endpoint1.name, DummyRequestPair)
+    assert not endpoint3.is_remote_subscribed_to(endpoint2.name, DummyRequestPair)
+    assert not endpoint3.is_remote_subscribed_to("nonexistent", DummyRequestPair)
+
+    assert not endpoint3.is_remote_subscribed_to(endpoint1.name, DummyResponse)
+    assert not endpoint3.is_remote_subscribed_to(endpoint2.name, DummyResponse)
+
+    endpoint1.stop()
+    endpoint2.stop()
+    endpoint3.stop()
+
+
+@pytest.mark.asyncio
+async def test_wait_until_all_subscribed(triplet_of_endpoints):
+    endpoint1, endpoint2, endpoint3 = triplet_of_endpoints
+
+    await endpoint1.subscribe(DummyRequestPair, lambda _: None)
+
+    await endpoint2.subscribe(DummyRequestPair, lambda _: None)
+
+    await endpoint3.wait_until_all_remotes_subscribed_to(DummyRequestPair)
+
+    subscriptions = endpoint3.get_connected_endpoints_and_subscriptions()
+
+    assert (endpoint1.name, {DummyRequestPair}) in subscriptions
+    assert (endpoint2.name, {DummyRequestPair}) in subscriptions
+
+    assert endpoint3.is_remote_subscribed_to(endpoint1.name, DummyRequestPair)
+    assert endpoint3.is_remote_subscribed_to(endpoint2.name, DummyRequestPair)
+    assert not endpoint3.is_remote_subscribed_to("nonexistent", DummyRequestPair)
+
+    assert not endpoint3.is_remote_subscribed_to(endpoint1.name, DummyResponse)
+    assert not endpoint3.is_remote_subscribed_to(endpoint2.name, DummyResponse)
+
+    endpoint1.stop()
+    endpoint2.stop()
+    endpoint3.stop()
+
+
+@pytest.mark.asyncio
+async def test_wait_until_specific_subscribed(triplet_of_endpoints):
+    endpoint1, endpoint2, endpoint3 = triplet_of_endpoints
+
+    await endpoint1.subscribe(DummyRequestPair, lambda _: None)
+
+    await endpoint3.wait_until_remote_subscribed_to(endpoint1.name, DummyRequestPair)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(
+            endpoint3.wait_until_all_remotes_subscribed_to(DummyRequestPair), 0.01
+        )
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(
+            endpoint3.wait_until_remote_subscribed_to(endpoint2.name, DummyRequestPair),
+            0.01,
+        )
+
+    subscriptions = endpoint3.get_connected_endpoints_and_subscriptions()
+
+    assert (endpoint1.name, {DummyRequestPair}) in subscriptions
+    assert not (endpoint2.name, {DummyRequestPair}) in subscriptions
+
+    assert endpoint3.is_remote_subscribed_to(endpoint1.name, DummyRequestPair)
+    assert not endpoint3.is_remote_subscribed_to(endpoint2.name, DummyRequestPair)
+
+    assert not endpoint3.is_remote_subscribed_to("nonexistent", DummyRequestPair)
+
+    endpoint1.stop()
+    endpoint2.stop()
+    endpoint3.stop()


### PR DESCRIPTION
## What was wrong?

The current APIs that let one wait on remote subscriptions aren't flexible enough and aren't generalized enough to be shared across the `TrioEndpoint`

See previous discussion: https://github.com/ethereum/lahja/pull/72#issuecomment-494425741

## How was it fixed?

1. Every specific endpoint has to implement the following API

```python
    @abstractmethod
    def get_connected_endpoints_and_subscriptions(
        self
    ) -> Tuple[Tuple[str, Set[Type[BaseEvent]]], ...]:
        """
        Return all connected endpoints and their event type subscriptions to this endpoint.
        """
        pass
```

@pipermerriam This is where this PR diverges from your proposal because I *think* this single API should be enough. If a connected remote endpoint does not hold event subscriptions it will still be listed here with an empty set. So, I don't think we need to have a separate API. And even if, this seperate API could be build inside the `BaseEndpoint` on top of this API.

2. Every endpoint needs to raise the internal `RemoteSubscriptionChanged` event if the known set of remote subscription changes. 

3. The `BaseEndpoint` defines four new APIs that are hence shared across all specific endpoints.

```python
    def is_remote_subscribed_to(
        self, remote_endpoint: str, event_type: Type[BaseEvent]
    ) -> bool:
        """
        Return ``True`` if the specified remote endpoint is subscribed to the specified event type
        from this endpoint. Otherwise return ``False``.
        """
  
    def is_any_remote_subscribed_to(self, event_type: Type[BaseEvent]) -> bool:
        """
        Return ``True`` if at least one of the connected remote endpoints is subscribed to the
        specified event type from this endpoint. Otherwise return ``False``.
  
    def are_all_remotes_subscribed_to(self, event_type: Type[BaseEvent]) -> bool:
        """
        Return ``True`` if every connected remote endpoint is subscribed to the specified event
        type from this endpoint. Otherwise return ``False``.
        """
  
    async def wait_until_remote_subscribed_to(
        self, remote_endpoint: str, event: Type[BaseEvent]
    ) -> None:
        """
        Block until the specified remote endpoint has subscribed to the specified event type
        from this endpoint.
        """

    async def wait_until_any_remote_subscribed_to(self, event: Type[BaseEvent]) -> None:
        """
        Block until any other remote endpoint has subscribed to the specified event type
        from this endpoint.
        """

    async def wait_until_all_remotes_subscribed_to(
        self, event: Type[BaseEvent]
    ) -> None:
        """
        Block until all currently connected remote endpoints are subscribed to the specified
        event type from this endpoint.
        """
```


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2016/11/cute-baby-chameleons-58302806509ed__700.jpg)
