### PR TITLE
Error check in main connect_to_endpoint API

### DIFF
--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -509,6 +509,7 @@ class AsyncioEndpoint(BaseEndpoint):
         await self.connect_to_endpoint(endpoint)
 
     async def connect_to_endpoint(self, config: ConnectionConfig) -> None:
+        self._throw_if_already_connected(config)
         if config.name in self._outbound_connections.keys():
             self.logger.warning(
                 "Tried to connect to %s but we are already connected to that Endpoint",

--- a/tests/core/asyncio/test_connect.py
+++ b/tests/core/asyncio/test_connect.py
@@ -12,11 +12,11 @@ async def test_can_not_connect_conflicting_names():
 
     # We connect to our own Endpoint because for this test, it doesn't matter
     # if we use a foreign one or our own
-    await endpoint.connect_to_endpoints(own)
+    await endpoint.connect_to_endpoint(own)
 
     # Can't connect a second time
     with pytest.raises(ConnectionAttemptRejected):
-        await endpoint.connect_to_endpoints(own)
+        await endpoint.connect_to_endpoint(own)
 
     endpoint.stop()
 


### PR DESCRIPTION
## What was wrong?

The `Endpoint.connect_to_endpoint` API was not checking for an existing connection.

## How was it fixed?

Added the check and updated test to exercise that code path.

#### Cute Animal Picture

![Muffin-The-Mini-Mule-A-Cr-006](https://user-images.githubusercontent.com/824194/58122149-32f26c00-7bc6-11e9-99a4-ba71e476473c.jpg)
