### PR TITLE
BaseEvent.bind API

### DIFF
--- a/lahja/common.py
+++ b/lahja/common.py
@@ -12,6 +12,8 @@ from typing import (  # noqa: F401
     Union,
 )
 
+from lahja.exceptions import BindError
+
 if TYPE_CHECKING:
     from lahja.base import EndpointAPI
 
@@ -61,7 +63,7 @@ class BaseEvent:
 
     def bind(self, endpoint: "EndpointAPI", id: Optional[str]) -> None:
         if self.is_bound:
-            raise RuntimeError("Event is already bound")
+            raise BindError("Event is already bound")
         self._origin = endpoint.name
         self._id = id
         self.is_bound = True

--- a/lahja/common.py
+++ b/lahja/common.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import (  # noqa: F401
+    TYPE_CHECKING,
     Any,
     Callable,
     Generic,
@@ -10,6 +11,9 @@ from typing import (  # noqa: F401
     TypeVar,
     Union,
 )
+
+if TYPE_CHECKING:
+    from lahja.base import EndpointAPI
 
 
 class Subscription:
@@ -52,7 +56,15 @@ class BaseEvent:
 
     _origin = ""
     _id: Optional[str] = None
-    _config: Optional[BroadcastConfig] = None
+
+    is_bound = False
+
+    def bind(self, endpoint: "EndpointAPI", id: Optional[str]) -> None:
+        if self.is_bound:
+            raise RuntimeError("Event is already bound")
+        self._origin = endpoint.name
+        self._id = id
+        self.is_bound = True
 
     def broadcast_config(self, internal: bool = False) -> BroadcastConfig:
         if internal:

--- a/lahja/exceptions.py
+++ b/lahja/exceptions.py
@@ -6,7 +6,13 @@ class LahjaError(Exception):
     pass
 
 
-class ConnectionAttemptRejected(Exception):
+class BindError(LahjaError):
+    """
+    Raise when an attempt was made to bind an event that is already bound.
+    """
+
+
+class ConnectionAttemptRejected(LahjaError):
     """
     Raised when an attempt was made to connect to an endpoint that is already connected.
     """
@@ -30,4 +36,8 @@ class UnexpectedResponse(LahjaError):
 
 
 class RemoteDisconnected(LahjaError):
+    """
+    Raise when a remote disconnects while we attempting to read a message.
+    """
+
     pass


### PR DESCRIPTION
## What was wrong?

Both the `broadcast` and `request` methods were setting private attributes of the `BaseEvent`

## How was it fixed?

Added `BaseEvent.bind` API to deal with these and internal `_broadcast` implementation that does the binding in a common location.

#### Cute Animal Picture

![RedPom2012](https://user-images.githubusercontent.com/824194/58123684-9e8a0880-7bc9-11e9-9fec-75f0be6aa3dd.jpg)

