### PR TITLE
Add broadcast_nowait to core API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,10 +1,25 @@
 API Docs
 ========
 
-Endpoint
---------
+Base Endpoint API
+-----------------
 
-.. automodule:: lahja.endpoint
+.. automodule:: lahja.base.EndpointAPI
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+.. automodule:: lahja.base.BaseEndpoint
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+AsyncioEndpoint
+---------------
+
+.. automodule:: lahja.asyncio.endpoint
     :members:
     :undoc-members:
     :show-inheritance:
@@ -18,6 +33,7 @@ ConnectionConfig
     :undoc-members:
     :show-inheritance:
 
+
 Exceptions
 ----------
 
@@ -25,6 +41,7 @@ Exceptions
     :members:
     :undoc-members:
     :show-inheritance:
+
 
 BaseEvent
 ---------
@@ -34,6 +51,7 @@ BaseEvent
     :undoc-members:
     :show-inheritance:
 
+
 BaseRequestResponseEvent
 ------------------------
 
@@ -41,6 +59,7 @@ BaseRequestResponseEvent
     :members:
     :undoc-members:
     :show-inheritance:
+
 
 BroadcastConfig
 ---------------
@@ -50,6 +69,7 @@ BroadcastConfig
     :undoc-members:
     :show-inheritance:
 
+
 Subscription
 ------------
 
@@ -57,5 +77,3 @@ Subscription
     :members:
     :undoc-members:
     :show-inheritance:
-
-

--- a/lahja/base.py
+++ b/lahja/base.py
@@ -140,6 +140,25 @@ class EndpointAPI(ABC):
         pass
 
     @abstractmethod
+    def broadcast_nowait(
+        self, item: BaseEvent, config: Optional[BroadcastConfig] = None
+    ) -> None:
+        """
+        A sync compatible version of :meth:`~lahja.base.EndpointAPI.broadcast`
+
+        .. warning::
+
+            Heavy use of :meth:`~lahja.base.EndpointAPI.broadcast_nowait` in
+            contiguous blocks of code without yielding to the `async`
+            implementation should be expected to cause problems.  Without
+            yielding, the braodcasted events will typically build back-pressure
+            either in the form of unbounded memory growth or errors due to full
+            queues.
+
+        """
+        pass
+
+    @abstractmethod
     async def request(
         self,
         item: BaseRequestResponseEvent[TResponse],

--- a/lahja/base.py
+++ b/lahja/base.py
@@ -150,10 +150,7 @@ class EndpointAPI(ABC):
 
             Heavy use of :meth:`~lahja.base.EndpointAPI.broadcast_nowait` in
             contiguous blocks of code without yielding to the `async`
-            implementation should be expected to cause problems.  Without
-            yielding, the braodcasted events will typically build back-pressure
-            either in the form of unbounded memory growth or errors due to full
-            queues.
+            implementation should be expected to cause problems.
 
         """
         pass


### PR DESCRIPTION
fixes #64

## What was wrong?

It turns out that `Endpoint.broadcast_nowait` is likely necessary.  Without it you simply cannot talk to the event bus from APIs that are synchronous.

## How was it fixed?

No core change other than adding it to the core API definition.

> I plan to majorly expand the test suite soon but only after I get the reverse server -> client connection stuff in because it improves the testing experience significantly

#### Cute Animal Picture

![Cute-Goats-Photo-06](https://user-images.githubusercontent.com/824194/58127283-3986e080-7bd2-11e9-9e30-f8c1b8b170e2.jpg)
