### PR TITLE
Standardize internal connection API

### DIFF
--- a/lahja/base.py
+++ b/lahja/base.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 import logging
+from pathlib import Path
 from typing import (  # noqa: F401
     Any,
     AsyncContextManager,
@@ -23,6 +24,8 @@ from .common import (
     BaseRequestResponseEvent,
     BroadcastConfig,
     ConnectionConfig,
+    Message,
+    Msg,
     Subscription,
 )
 
@@ -30,6 +33,21 @@ TResponse = TypeVar("TResponse", bound=BaseEvent)
 TWaitForEvent = TypeVar("TWaitForEvent", bound=BaseEvent)
 TSubscribeEvent = TypeVar("TSubscribeEvent", bound=BaseEvent)
 TStreamEvent = TypeVar("TStreamEvent", bound=BaseEvent)
+
+
+class ConnectionAPI(ABC):
+    @classmethod
+    @abstractmethod
+    async def connect_to(cls, path: Path) -> "ConnectionAPI":
+        ...
+
+    @abstractmethod
+    async def send_message(self, message: Msg) -> None:
+        pass
+
+    @abstractmethod
+    async def read_message(self) -> Message:
+        pass
 
 
 class EndpointAPI(ABC):

--- a/lahja/common.py
+++ b/lahja/common.py
@@ -6,6 +6,7 @@ from typing import (  # noqa: F401
     Generic,
     NamedTuple,
     Optional,
+    Set,
     Type,
     TypeVar,
     Union,
@@ -99,3 +100,32 @@ class ConnectionConfig(NamedTuple):
 class Broadcast(NamedTuple):
     event: Union[BaseEvent, bytes]
     config: Optional[BroadcastConfig]
+
+
+class Message(ABC):
+    """
+    Base class for all valid message types that an ``Endpoint`` can handle.
+    ``NamedTuple`` breaks multiple inheritance which means, instead of regular subclassing,
+    derived message types need to derive from ``NamedTuple`` directly and call
+    Message.register(DerivedType) in order to allow isinstance(obj, Message) checks.
+    """
+
+    pass
+
+
+class SubscriptionsUpdated(NamedTuple):
+    subscriptions: Set[Type[BaseEvent]]
+    response_expected: bool
+
+
+class SubscriptionsAck:
+    pass
+
+
+Message.register(Broadcast)
+Message.register(SubscriptionsUpdated)
+Message.register(SubscriptionsAck)
+
+
+# mypy doesn't appreciate the ABCMeta trick
+Msg = Union[Broadcast, SubscriptionsUpdated, SubscriptionsAck]


### PR DESCRIPTION
## What was wrong?

As I started working on getting the `trio` endpoint up-to-speed with the latest changes it became apparent that there will be at lest some minimal re-usability needed between the concepts the endpoints use like the `InboundConnection` and `OutboundConnection`, primarily in the way that they interact with subscriptions.

Also, there were still some constructs living in `lahja.asyncio.endpoint` that belonged in `lahja.common`

## How was it fixed?

Wrote a simple `ABC` base class for the `Connection` API.

#### Cute Animal Picture

![NA9](https://user-images.githubusercontent.com/824194/58130335-06941b00-7bd9-11e9-8959-dd33263ade9c.jpg)

