### PR TITLE
optimize can_send_item a little

### DIFF
--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -228,14 +228,13 @@ class OutboundConnection:
                 await self.send_message(SubscriptionsAck())
 
     def can_send_item(self, item: BaseEvent, config: Optional[BroadcastConfig]) -> bool:
-        is_response = config is not None and config.filter_event_id is not None
-        passes_config = config is None or config.allowed_to_receive(self.name)
-        passes_filter = type(item) in self.subscribed_messages
+        if config is not None:
+            if not config.allowed_to_receive(self.name):
+                return False
+            elif config.filter_event_id is not None:
+                return True
 
-        if not passes_config:
-            return False
-
-        return is_response or passes_filter
+        return type(item) in self.subscribed_messages
 
     async def send_message(self, message: Msg) -> None:
         await self.conn.send_message(message)

--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -232,6 +232,7 @@ class OutboundConnection:
             if not config.allowed_to_receive(self.name):
                 return False
             elif config.filter_event_id is not None:
+                # the item is a response to a request.
                 return True
 
         return type(item) in self.subscribed_messages


### PR DESCRIPTION
## What was wrong?

The `OutboundConnection` object's `can_send_item` method checked *up-to* three things to determine if sending was valid.  The current implementation computed all three of these conditions and then iterated them in precedence order to determine the result.

This is sub-optimal because in cases where the function returns because of the highest precedence check, the lower precedence checks are not used.

## How was it fixed?

Adjust the function such that it only computes the minimal data it needs.

#### Cute Animal Picture


![miniature-hereford](https://user-images.githubusercontent.com/824194/58132998-f7fd3200-7bdf-11e9-825f-8a272e7415c4.jpg)
