### PR TITLE
Stop using uuid for request_id

### DIFF
--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -18,6 +18,7 @@ from typing import (  # noqa: F401
     Callable,
     DefaultDict,
     Dict,
+    Iterable,
     List,
     NamedTuple,
     Optional,
@@ -807,11 +808,13 @@ class AsyncioEndpoint(BaseEndpoint):
         self._queues[event_type].append(casted_queue)
         await self._notify_subscriptions_changed()
 
+        iterations: Iterable[int]
+
         if num_events is None:
             # loop forever
-            iterations = itertools.repeat(True)
+            iterations = itertools.count()
         else:
-            iterations = itertools.repeat(True, num_events)
+            iterations = range(num_events)
 
         try:
             for _ in iterations:

--- a/lahja/base.py
+++ b/lahja/base.py
@@ -219,6 +219,12 @@ class BaseEndpoint(EndpointAPI):
 
     logger = logging.getLogger("lahja.endpoint.Endpoint")
 
+    def __str__(self) -> str:
+        return f"Endpoint[{self.name}]"
+
+    def __repr__(self) -> str:
+        return f"<{self.name}>"
+
     #
     # Common implementations
     #

--- a/lahja/tools/benchmark/typing.py
+++ b/lahja/tools/benchmark/typing.py
@@ -1,6 +1,6 @@
-from typing import NamedTuple
+from typing import NamedTuple, Type
 
-from lahja import BaseEvent
+from lahja import BaseEvent, BaseRequestResponseEvent
 
 
 class RawMeasureEntry(NamedTuple):
@@ -19,6 +19,21 @@ class PerfMeasureEvent(BaseEvent):
         self.payload = payload
         self.index = index
         self.sent_at = sent_at
+
+
+class PerfMeasureResponse(BaseEvent):
+    pass
+
+
+class PerfMeasureRequest(BaseRequestResponseEvent[PerfMeasureResponse]):
+    def __init__(self, payload: bytes, index: int, sent_at: float) -> None:
+        self.payload = payload
+        self.index = index
+        self.sent_at = sent_at
+
+    @staticmethod
+    def expected_response_type() -> Type[PerfMeasureResponse]:
+        return PerfMeasureResponse
 
 
 class ShutdownEvent(BaseEvent):

--- a/lahja/typing.py
+++ b/lahja/typing.py
@@ -1,0 +1,3 @@
+from typing import NewType
+
+RequestID = NewType("RequestID", bytes)

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,10 @@ commands=
     bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 100 --payload-bytes 1000000"
     bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 10 --payload-bytes 1000000"
 
+    # request/response
+    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 1000 --mode request"
+    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 100 --mode request"
+
 [testenv:snappy-benchmark]
 usedevelop=True
 commands=


### PR DESCRIPTION
Builds on #99 

## What was wrong?

The cost of generating a UUID is *maybe* more expensive.

## How was it fixed?

Custom scheme that *might* have minimal overhead.

- [x] TODO: benchmark suite does not flex the `request/response` API.

#### Cute Animal Picture

![35843c422aaa96acff54869fa97ef8e4](https://user-images.githubusercontent.com/824194/58429848-66b91000-8064-11e9-8d02-3a4e6cf52cd0.jpg)

