### PR TITLE
Request/response benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,8 @@ Key facts:
 
 ## TODOs
 
-- Filter support (e.g. only subscribe to `EventX` from origin `y`)
 - Push boundaries (don't push this into process x)
 - Testing
-- Performance analysis
 
 ## Developer Setup
 

--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -18,6 +18,7 @@ from typing import (  # noqa: F401
     Callable,
     DefaultDict,
     Dict,
+    Iterable,
     List,
     NamedTuple,
     Optional,
@@ -807,11 +808,13 @@ class AsyncioEndpoint(BaseEndpoint):
         self._queues[event_type].append(casted_queue)
         await self._notify_subscriptions_changed()
 
+        iterations: Iterable[int]
+
         if num_events is None:
             # loop forever
-            iterations = itertools.repeat(True)
+            iterations = itertools.count()
         else:
-            iterations = itertools.repeat(True, num_events)
+            iterations = range(num_events)
 
         try:
             for _ in iterations:

--- a/lahja/tools/benchmark/typing.py
+++ b/lahja/tools/benchmark/typing.py
@@ -1,6 +1,6 @@
-from typing import NamedTuple
+from typing import NamedTuple, Type
 
-from lahja import BaseEvent
+from lahja import BaseEvent, BaseRequestResponseEvent
 
 
 class RawMeasureEntry(NamedTuple):
@@ -19,6 +19,21 @@ class PerfMeasureEvent(BaseEvent):
         self.payload = payload
         self.index = index
         self.sent_at = sent_at
+
+
+class PerfMeasureResponse(BaseEvent):
+    pass
+
+
+class PerfMeasureRequest(BaseRequestResponseEvent[PerfMeasureResponse]):
+    def __init__(self, payload: bytes, index: int, sent_at: float) -> None:
+        self.payload = payload
+        self.index = index
+        self.sent_at = sent_at
+
+    @staticmethod
+    def expected_response_type() -> Type[PerfMeasureResponse]:
+        return PerfMeasureResponse
 
 
 class ShutdownEvent(BaseEvent):

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,10 @@ commands=
     bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 100 --payload-bytes 1000000"
     bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 10 --payload-bytes 1000000"
 
+    # request/response
+    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 1000 --mode request"
+    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 100 --mode request"
+
 [testenv:snappy-benchmark]
 usedevelop=True
 commands=


### PR DESCRIPTION
unblocks https://github.com/ethereum/lahja/pull/98

## What was wrong?

Our benchmark tests do not cover the `EndpointAPI.request` code path.

## How was it fixed?

Added ability to target that API to benchmark suite using `--mode request`

#### Cute Animal Picture


![cute-baby-hippos-7-590842bb42d16__700](https://user-images.githubusercontent.com/824194/58639422-1a640f00-82b4-11e9-965b-90782fb8d53b.jpg)
