### PR TITLE
Add subscribe_nowait method

### DIFF
--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -841,15 +841,13 @@ class AsyncioEndpoint(BaseEndpoint):
         # that's a performance problem, not a correctness problem.
         self._subscriptions_changed.set()
 
-    async def subscribe(
+    def subscribe_nowait(
         self,
         event_type: Type[TSubscribeEvent],
         handler: Callable[[TSubscribeEvent], Union[Any, Awaitable[Any]]],
     ) -> Subscription:
         """
-        Subscribe to receive updates for any event that matches the specified event type.
-        A handler is passed as a second argument an :class:`~lahja.common.Subscription` is returned
-        to unsubscribe from the event if needed.
+        A sync compatible version of :meth:`~lahja.asyncio.AsyncioEndpoint.subscribe`
         """
         if inspect.iscoroutine(handler):
             casted_handler = cast(SubscriptionAsyncHandler, handler)
@@ -867,6 +865,18 @@ class AsyncioEndpoint(BaseEndpoint):
         self._subscriptions_changed.set()
 
         return Subscription(unsubscribe_fn)
+
+    async def subscribe(
+        self,
+        event_type: Type[TSubscribeEvent],
+        handler: Callable[[TSubscribeEvent], Union[Any, Awaitable[Any]]],
+    ) -> Subscription:
+        """
+        Subscribe to receive updates for any event that matches the specified event type.
+        A handler is passed as a second argument an :class:`~lahja.common.Subscription` is returned
+        to unsubscribe from the event if needed.
+        """
+        return self.subscribe_nowait(event_type, handler)
 
     async def stream(
         self, event_type: Type[TStreamEvent], num_events: Optional[int] = None

--- a/lahja/base.py
+++ b/lahja/base.py
@@ -207,6 +207,19 @@ class EndpointAPI(ABC):
         """
         ...
 
+    def subscribe_nowait(
+        self,
+        event_type: Type[TSubscribeEvent],
+        handler: Callable[[TSubscribeEvent], Union[Any, Awaitable[Any]]],
+    ) -> Subscription:
+        """
+        A sync compatible version of :meth:`~lahja.base.EndpointAPI.subscribe`
+
+        Instead of blocking the calling coroutine this function schedules the subscribe
+        and immediately returns.
+        """
+        ...
+
     @abstractmethod
     async def stream(
         self, event_type: Type[TStreamEvent], num_events: Optional[int] = None


### PR DESCRIPTION
## What was wrong?

The `subscribe`  API is often used as an escape hatch to subscribe to events from synchronous methods. Recently that method became `async` by default and looking into Trinity there seem to be a lot of places that would probably need to broader refactoring to turn them into `async` methods.

## How was it fixed?

Since Trinity is currently on a lahja git ref, my main motivation here is to give us something that would quickly resolve the situation so that we can cut a new release. This adds a new API `subscribe_nowait` that can be used as a drop in replacement for the old API. Notice that it still has the additional feature of being able to accept async handlers.

Also this fixes the issue of not using `iscoroutinefunction` for the handler check.

I intentionally did not add this to the `EndpointAPI` as I'm not sure if we want to support it long term.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/WMVgAMcm_YY/maxresdefault.jpg)
