### PR TITLE
Generic wait for subscriptions and connection change

### DIFF
--- a/lahja/common.py
+++ b/lahja/common.py
@@ -94,10 +94,6 @@ class BaseRequestResponseEvent(ABC, BaseEvent, Generic[TResponse]):
         raise NotImplementedError("Must be implemented by subsclasses")
 
 
-class RemoteSubscriptionChanged(BaseEvent):
-    pass
-
-
 class ConnectionConfig(NamedTuple):
     """
     Configuration class needed to establish :class:`~lahja.endpoint.Endpoint` connections.

--- a/tests/core/asyncio/test_asyncio_subscriptions_api.py
+++ b/tests/core/asyncio/test_asyncio_subscriptions_api.py
@@ -194,7 +194,7 @@ async def test_asyncio_wait_until_any_remote_subscribed_to(
     asyncio.ensure_future(server_a.subscribe(WaitSubscription, noop))
 
     await asyncio.wait_for(
-        client.wait_until_any_remote_subscribed_to(WaitSubscription), timeout=0.1
+        client.wait_until_any_remote_subscribed_to(WaitSubscription), timeout=1
     )
 
 

--- a/tests/core/asyncio/test_base_wait_connections_changed_api.py
+++ b/tests/core/asyncio/test_base_wait_connections_changed_api.py
@@ -1,0 +1,18 @@
+import asyncio
+
+import pytest
+
+from conftest import generate_unique_name
+from lahja import AsyncioEndpoint, ConnectionConfig
+
+
+@pytest.mark.asyncio
+async def test_base_wait_until_connections_changed():
+    config = ConnectionConfig.from_name(generate_unique_name())
+    async with AsyncioEndpoint.serve(config):
+        async with AsyncioEndpoint("client").run() as client:
+            asyncio.ensure_future(client.connect_to_endpoint(config))
+
+            assert not client.is_connected_to(config.name)
+            await asyncio.wait_for(client.wait_until_connections_change(), timeout=0.1)
+            assert client.is_connected_to(config.name)

--- a/tests/core/asyncio/test_connect.py
+++ b/tests/core/asyncio/test_connect.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from conftest import generate_unique_name
@@ -10,6 +12,18 @@ async def test_connect_to_endpoint():
     async with AsyncioEndpoint.serve(config):
         async with AsyncioEndpoint("client").run() as client:
             await client.connect_to_endpoint(config)
+            assert client.is_connected_to(config.name)
+
+
+@pytest.mark.asyncio
+async def test_wait_until_connected_to():
+    config = ConnectionConfig.from_name(generate_unique_name())
+    async with AsyncioEndpoint.serve(config):
+        async with AsyncioEndpoint("client").run() as client:
+            asyncio.ensure_future(client.connect_to_endpoint(config))
+
+            assert not client.is_connected_to(config.name)
+            await client.wait_until_connected_to(config.name)
             assert client.is_connected_to(config.name)
 
 


### PR DESCRIPTION
Builds from #107 

## What was wrong?

I didn't like that the generic implemetnations of the various subscription based `wait` APIs prescribed implementation details, primarily, that each implementation was required to implement something that streamed an event over the local bus to signal the change.

We also need an api for waiting until a connection is established to a specific endpoint.

## How was it fixed?

Now there are two methods that each endpoint must implement:

- `wait_until_remote_subscriptions_change`
- `wait_until_connections_change`

From these two APIs, all of the following can be constructed generically in the `BaseEndpoint` class.
- `wait_until_connections_change`
    - `wait_until_connected_to` (new API)
- `wait_until_remote_subscriptions_change`
    - `are_all_remotes_subscribed_to`
    - `wait_until_any_remote_subscribed_to`
    - `wait_until_all_remotes_subscribed_to`

#### Cute Animal Picture

![Cute Baby Hippo (4)](https://user-images.githubusercontent.com/824194/58635444-28616200-82ab-11e9-9bc0-ab8ac72c264e.jpg)
