### PR TITLE
Misc cleanups

### DIFF
--- a/lahja/tools/benchmark/process.py
+++ b/lahja/tools/benchmark/process.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractmethod
 import itertools
 import logging
 import multiprocessing
+import os
+import signal
 import time
 from typing import Any, AsyncGenerator, List, NamedTuple, Optional, Tuple  # noqa: F401
 
@@ -46,15 +48,26 @@ class BaseDriverProcess(ABC):
 
     def stop(self) -> None:
         assert self._process is not None
-        self._process.terminate()
-        self._process.join(1)
+        if self._process.pid is not None:
+            os.kill(self._process.pid, signal.SIGINT)
+        else:
+            self._process.terminate()
+
+        try:
+            self._process.join(1)
+        except TimeoutError:
+            self._process.terminate()
+            self._process.join(1)
 
     @classmethod
     def launch(cls, config: DriverProcessConfig) -> None:
         # UNCOMMENT FOR DEBUGGING
         # logger = multiprocessing.log_to_stderr()
         # logger.setLevel(logging.INFO)
-        config.backend.run(cls.worker, config)
+        try:
+            config.backend.run(cls.worker, config)
+        except KeyboardInterrupt:
+            return
 
     @classmethod
     async def worker(cls, config: DriverProcessConfig) -> None:
@@ -125,10 +138,10 @@ class BaseConsumerProcess(ABC):
             await event_bus.connect_to_endpoints(
                 ConnectionConfig.from_name(REPORTER_ENDPOINT)
             )
-            await event_bus.wait_until_all_remotes_subscribed_to(TotalRecordedEvent)
 
             stats = await cls.do_consumer(event_bus, num_events)
 
+            await event_bus.wait_until_all_remotes_subscribed_to(TotalRecordedEvent)
             await event_bus.broadcast(
                 TotalRecordedEvent(stats.crunch(event_bus.name)),
                 BroadcastConfig(filter_endpoint=REPORTER_ENDPOINT),

--- a/lahja/tools/benchmark/process.py
+++ b/lahja/tools/benchmark/process.py
@@ -138,10 +138,10 @@ class BaseConsumerProcess(ABC):
             await event_bus.connect_to_endpoints(
                 ConnectionConfig.from_name(REPORTER_ENDPOINT)
             )
+            await event_bus.wait_until_all_remotes_subscribed_to(TotalRecordedEvent)
 
             stats = await cls.do_consumer(event_bus, num_events)
 
-            await event_bus.wait_until_all_remotes_subscribed_to(TotalRecordedEvent)
             await event_bus.broadcast(
                 TotalRecordedEvent(stats.crunch(event_bus.name)),
                 BroadcastConfig(filter_endpoint=REPORTER_ENDPOINT),

--- a/tests/core/asyncio/test_asyncio_subscriptions_api.py
+++ b/tests/core/asyncio/test_asyncio_subscriptions_api.py
@@ -193,6 +193,9 @@ async def test_asyncio_wait_until_any_remote_subscribed_to(
 
     asyncio.ensure_future(server_a.subscribe(WaitSubscription, noop))
 
+    # verify it's not currently subscribed.
+    assert not client.is_any_remote_subscribed_to(WaitSubscription)
+
     await asyncio.wait_for(
         client.wait_until_any_remote_subscribed_to(WaitSubscription), timeout=1
     )


### PR DESCRIPTION
## What was wrong?

I ditched a branch but it had some cleanups I wanted to maintain that are a bit random.

## How was it fixed?

Combined them into this single PR.

- `__str__` and `__repr__` methods for `RemoteEndpoint`
- some code comments
- a minor bugfix in the resource locking of `RemoteEndpoint.subscribed_messages`
- `__str__` and `__repr__` methods for `AsyncioEndpoint`
- Nicer killing of the main driver process in the benchmarks.
- Wait until later to block on subscription in the benchmark reporter process
- A pre-assertion for a test

#### Cute Animal Picture

![IRBSY7C](https://user-images.githubusercontent.com/824194/58639352-ff919a80-82b3-11e9-917c-1774a0eaffdb.jpg)

