### PR TITLE
Abstract base API for RemoteEndpoint

### DIFF
--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -36,6 +36,7 @@ from async_generator import asynccontextmanager
 from lahja._snappy import check_has_snappy_support
 from lahja.base import (
     BaseEndpoint,
+    BaseRemoteEndpoint,
     ConnectionAPI,
     RemoteEndpointAPI,
     TResponse,
@@ -126,35 +127,14 @@ class Connection(ConnectionAPI):
             raise RemoteDisconnected()
 
 
-class RemoteEndpoint(RemoteEndpointAPI):
-    """
-    Represents a connection to another endpoint.  Connections *can* be
-    bi-directional with messages flowing in either direction.
-
-    A 'message' can be any of:
-
-    - ``SubscriptionsUpdated``
-            broadcasting the subscriptions that the endpoint on the other side
-            of this connection is interested in.
-    - ``SubscriptionsAck``
-            acknowledgedment of a ``SubscriptionsUpdated``
-    - ``Broadcast``
-            an event meant to be processed by the endpoint.
-    """
-
-    logger = logging.getLogger("lahja.endpoint.asyncio.RemoteEndpoint")
-
+class AsyncioRemoteEndpoint(BaseRemoteEndpoint):
     def __init__(
         self,
         name: Optional[str],
-        conn: Connection,
+        conn: ConnectionAPI,
         new_msg_func: Callable[[Broadcast], Awaitable[Any]],
     ) -> None:
-        self.name = name
-        self.conn = conn
-        self.new_msg_func = new_msg_func
-
-        self.subscribed_messages: Set[Type[BaseEvent]] = set()
+        super().__init__(name, conn, new_msg_func)
 
         self._notify_lock = asyncio.Lock()  # type: ignore
 
@@ -163,24 +143,6 @@ class RemoteEndpoint(RemoteEndpointAPI):
 
         self._running = asyncio.Event()  # type: ignore
         self._stopped = asyncio.Event()  # type: ignore
-
-    def __str__(self) -> str:
-        return f"RemoteEndpoint[{self.name if self.name is not None else id(self)}]"
-
-    def __repr__(self) -> str:
-        return f"<{self}>"
-
-    async def wait_started(self) -> None:
-        await self._running.wait()
-
-    async def wait_stopped(self) -> None:
-        await self._stopped.wait()
-
-    async def is_running(self) -> bool:
-        return not self.is_stopped and self.running.is_set()
-
-    async def is_stopped(self) -> bool:
-        return self._stopped.is_set()
 
     async def start(self) -> None:
         self._task = asyncio.ensure_future(self._run())
@@ -220,50 +182,6 @@ class RemoteEndpoint(RemoteEndpointAPI):
                     await self.send_message(SubscriptionsAck())
             else:
                 self.logger.error(f"received unexpected message: {message}")
-
-    async def notify_subscriptions_updated(
-        self, subscriptions: Set[Type[BaseEvent]], block: bool = True
-    ) -> None:
-        """
-        Alert the endpoint on the other side of this connection that the local
-        subscriptions have changed. If ``block`` is ``True`` then this function
-        will block until the remote endpoint has acknowledged the new
-        subscription set. If ``block`` is ``False`` then this function will
-        return immediately after the send finishes.
-        """
-        # The extra lock ensures only one coroutine can notify this endpoint at any one time
-        # and that no replies are accidentally received by the wrong
-        # coroutines. Without this, in the case where `block=True`, this inner
-        # block would release the lock on the call to `wait()` which would
-        # allow the ack from a different update to incorrectly result in this
-        # returning before the ack had been received.
-        async with self._notify_lock:
-            async with self._received_response:
-                try:
-                    await self.conn.send_message(
-                        SubscriptionsUpdated(subscriptions, block)
-                    )
-                except RemoteDisconnected:
-                    return
-                if block:
-                    await self._received_response.wait()
-
-    def can_send_item(self, item: BaseEvent, config: Optional[BroadcastConfig]) -> bool:
-        if config is not None:
-            if self.name is not None and not config.allowed_to_receive(self.name):
-                return False
-            elif config.filter_event_id is not None:
-                # the item is a response to a request.
-                return True
-
-        return type(item) in self.subscribed_messages
-
-    async def send_message(self, message: Msg) -> None:
-        await self.conn.send_message(message)
-
-    async def wait_until_subscription_received(self) -> None:
-        async with self._received_subscription:
-            await self._received_subscription.wait()
 
 
 @asynccontextmanager  # type: ignore
@@ -442,7 +360,7 @@ class AsyncioEndpoint(BaseEndpoint):
 
     async def _accept_conn(self, reader: StreamReader, writer: StreamWriter) -> None:
         conn = Connection(reader, writer)
-        remote = RemoteEndpoint(None, conn, self._receiving_queue.put)
+        remote = AsyncioRemoteEndpoint(None, conn, self._receiving_queue.put)
         self._half_connections.add(remote)
 
         task = asyncio.ensure_future(self._handle_client(remote))
@@ -584,7 +502,7 @@ class AsyncioEndpoint(BaseEndpoint):
             return
 
         conn = await Connection.connect_to(config.path)
-        remote = RemoteEndpoint(config.name, conn, self._receiving_queue.put)
+        remote = AsyncioRemoteEndpoint(config.name, conn, self._receiving_queue.put)
 
         task = asyncio.ensure_future(self._handle_server(remote))
 

--- a/lahja/base.py
+++ b/lahja/base.py
@@ -23,12 +23,15 @@ from typing import (  # noqa: F401
 from .common import (
     BaseEvent,
     BaseRequestResponseEvent,
+    Broadcast,
     BroadcastConfig,
     ConnectionConfig,
     Message,
     Msg,
     Subscription,
+    SubscriptionsUpdated,
 )
+from .exceptions import RemoteDisconnected
 from .typing import ConditionAPI, EventAPI, LockAPI
 
 TResponse = TypeVar("TResponse", bound=BaseEvent)
@@ -85,6 +88,9 @@ class RemoteEndpointAPI(ABC):
 
     _subscriptions_initialized: EventAPI
 
+    #
+    # Object run lifecycle
+    #
     @abstractmethod
     async def wait_started(self) -> None:
         ...
@@ -94,11 +100,11 @@ class RemoteEndpointAPI(ABC):
         ...
 
     @abstractmethod
-    async def is_running(self) -> bool:
+    def is_running(self) -> bool:
         ...
 
     @abstractmethod
-    async def is_stopped(self) -> bool:
+    def is_stopped(self) -> bool:
         ...
 
     @abstractmethod
@@ -113,6 +119,10 @@ class RemoteEndpointAPI(ABC):
     async def _run(self) -> None:
         ...
 
+    #
+    # Core external API
+    #
+    @abstractmethod
     async def notify_subscriptions_updated(
         self, subscriptions: Set[Type[BaseEvent]], block: bool = True
     ) -> None:
@@ -125,14 +135,103 @@ class RemoteEndpointAPI(ABC):
         """
         ...
 
+    @abstractmethod
     def can_send_item(self, item: BaseEvent, config: Optional[BroadcastConfig]) -> bool:
         ...
 
+    @abstractmethod
     async def send_message(self, message: Msg) -> None:
         ...
 
+    @abstractmethod
     async def wait_until_subscription_received(self) -> None:
         ...
+
+
+class BaseRemoteEndpoint(RemoteEndpointAPI):
+    """
+    This base class implements common logic that can be shared across different
+    implementations of the `RemoteEndpointAPI`
+
+    Represents a connection to another endpoint.  Connections *can* be
+    bi-directional with messages flowing in either direction.
+    """
+
+    logger = logging.getLogger("lahja.endpoint.asyncio.RemoteEndpoint")
+
+    def __init__(
+        self,
+        name: Optional[str],
+        conn: ConnectionAPI,
+        new_msg_func: Callable[[Broadcast], Awaitable[Any]],
+    ) -> None:
+        self.name = name
+        self.conn = conn
+        self.new_msg_func = new_msg_func
+
+        self.subscribed_messages: Set[Type[BaseEvent]] = set()
+
+    def __str__(self) -> str:
+        return f"RemoteEndpoint[{self.name if self.name is not None else id(self)}]"
+
+    def __repr__(self) -> str:
+        return f"<{self}>"
+
+    async def wait_started(self) -> None:
+        await self._running.wait()
+
+    async def wait_stopped(self) -> None:
+        await self._stopped.wait()
+
+    def is_running(self) -> bool:
+        return not self.is_stopped and self.running.is_set()
+
+    def is_stopped(self) -> bool:
+        return self._stopped.is_set()
+
+    async def notify_subscriptions_updated(
+        self, subscriptions: Set[Type[BaseEvent]], block: bool = True
+    ) -> None:
+        """
+        Alert the endpoint on the other side of this connection that the local
+        subscriptions have changed. If ``block`` is ``True`` then this function
+        will block until the remote endpoint has acknowledged the new
+        subscription set. If ``block`` is ``False`` then this function will
+        return immediately after the send finishes.
+        """
+        # The extra lock ensures only one coroutine can notify this endpoint at any one time
+        # and that no replies are accidentally received by the wrong
+        # coroutines. Without this, in the case where `block=True`, this inner
+        # block would release the lock on the call to `wait()` which would
+        # allow the ack from a different update to incorrectly result in this
+        # returning before the ack had been received.
+        async with self._notify_lock:
+            async with self._received_response:
+                try:
+                    await self.conn.send_message(
+                        SubscriptionsUpdated(subscriptions, block)
+                    )
+                except RemoteDisconnected:
+                    return
+                if block:
+                    await self._received_response.wait()
+
+    def can_send_item(self, item: BaseEvent, config: Optional[BroadcastConfig]) -> bool:
+        if config is not None:
+            if self.name is not None and not config.allowed_to_receive(self.name):
+                return False
+            elif config.filter_event_id is not None:
+                # the item is a response to a request.
+                return True
+
+        return type(item) in self.subscribed_messages
+
+    async def send_message(self, message: Msg) -> None:
+        await self.conn.send_message(message)
+
+    async def wait_until_subscription_received(self) -> None:
+        async with self._received_subscription:
+            await self._received_subscription.wait()
 
 
 class EndpointAPI(ABC):

--- a/lahja/typing.py
+++ b/lahja/typing.py
@@ -1,3 +1,83 @@
-from typing import NewType
+from abc import ABC, abstractmethod
+from types import TracebackType
+from typing import Any, Callable, NewType, Type
 
 RequestID = NewType("RequestID", bytes)
+
+
+class LockAPI(ABC):
+    @abstractmethod
+    async def __aenter__(self) -> None:
+        ...
+
+    @abstractmethod
+    async def __aexit__(
+        self, exc_type: Type[BaseException], exc_val: BaseException, tb: TracebackType
+    ) -> None:
+        ...
+
+    @abstractmethod
+    async def acquire(self) -> None:
+        ...
+
+    @abstractmethod
+    def locked(self) -> bool:
+        ...
+
+    @abstractmethod
+    def release(self) -> None:
+        ...
+
+
+class ConditionAPI(ABC):
+    @abstractmethod
+    async def __aenter__(self) -> None:
+        ...
+
+    @abstractmethod
+    async def __aexit__(
+        self, exc_type: Type[BaseException], exc_val: BaseException, tb: TracebackType
+    ) -> None:
+        ...
+
+    @abstractmethod
+    async def acquire(self) -> None:
+        ...
+
+    @abstractmethod
+    def notify_all(self) -> None:
+        ...
+
+    @abstractmethod
+    def notify(self, n: int) -> None:
+        ...
+
+    @abstractmethod
+    def release(self, n: int) -> None:
+        ...
+
+    @abstractmethod
+    async def wait(self) -> None:
+        ...
+
+    @abstractmethod
+    async def wait_for(self, predicate: Callable[[], Any]) -> None:
+        ...
+
+
+class EventAPI(ABC):
+    @abstractmethod
+    def is_set(self) -> bool:
+        ...
+
+    @abstractmethod
+    def set(self) -> None:
+        ...
+
+    @abstractmethod
+    def clear(self) -> None:
+        ...
+
+    @abstractmethod
+    async def wait(self) -> None:
+        ...


### PR DESCRIPTION
## What was wrong?

As we move towards multiple implementations of the endpoint concept, the more logic we can de-duplicate the better (mostly).  One thing limiting this is the framework specific `Event/Condition/Lock` classes.  As it turns out, these have the same API signature in both `asyncio` and `trio`.

We need a common way to define these standard APIs so that common non-framework specific business logic can move into base classes.  Part of this is a common definition of the shape of a `RemoteEndpoint`

## How was it fixed?

Implemented `BaseEndpointAPI` which defines the basics for interacting with a remote endpoint connection.

This includes `ABC` base classes for the `Lock/Condition/Event` APIs (though it requires a little coercion to get mypy to like it.)

#### Cute Animal Picture

![Cute Baby Hippo (1)](https://user-images.githubusercontent.com/824194/58831727-8fb04680-860a-11e9-8133-018da6f89d44.jpg)
