### PR TITLE
Make subscribe API non-async

### DIFF
--- a/examples/inter_process_ping_pong.py
+++ b/examples/inter_process_ping_pong.py
@@ -40,13 +40,13 @@ def run_proc1():
 async def proc1_worker():
     async with AsyncioEndpoint.serve(ConnectionConfig.from_name("e1")) as endpoint:
         await endpoint.connect_to_endpoints(ConnectionConfig.from_name("e2"))
-        await endpoint.subscribe(
+        endpoint.subscribe(
             SecondThingHappened,
             lambda event: logging.info(
                 "Received via SUBSCRIBE API in proc1: %s", event.payload
             ),
         )
-        await endpoint.subscribe(
+        endpoint.subscribe(
             FirstThingHappened,
             lambda event: logging.info("Receiving own event: %s", event.payload),
         )
@@ -69,7 +69,7 @@ async def proc2_worker():
     async with AsyncioEndpoint.serve(ConnectionConfig.from_name("e2")) as endpoint:
         await endpoint.connect_to_endpoints(ConnectionConfig.from_name("e1"))
         asyncio.ensure_future(display_proc1_events(endpoint))
-        await endpoint.subscribe(
+        endpoint.subscribe(
             FirstThingHappened,
             lambda event: logging.info(
                 "Received via SUBSCRIBE API in proc2: %s", event.payload

--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -841,7 +841,7 @@ class AsyncioEndpoint(BaseEndpoint):
         # that's a performance problem, not a correctness problem.
         self._subscriptions_changed.set()
 
-    async def subscribe(
+    def subscribe(
         self,
         event_type: Type[TSubscribeEvent],
         handler: Callable[[TSubscribeEvent], Union[Any, Awaitable[Any]]],

--- a/lahja/base.py
+++ b/lahja/base.py
@@ -195,7 +195,7 @@ class EndpointAPI(ABC):
         ...
 
     @abstractmethod
-    async def subscribe(
+    def subscribe(
         self,
         event_type: Type[TSubscribeEvent],
         handler: Callable[[TSubscribeEvent], Union[Any, Awaitable[Any]]],

--- a/tests/core/asyncio/test_asyncio_subscriptions_api.py
+++ b/tests/core/asyncio/test_asyncio_subscriptions_api.py
@@ -130,7 +130,7 @@ async def test_asyncio_subscribe_updates_subscriptions(pair_of_endpoints):
 
     # trigger a `wait_for` call to run in the background and give it a moment
     # to spin up.
-    subscription = await subscriber.subscribe(SubscribeEvent, received_events.append)
+    subscription = subscriber.subscribe(SubscribeEvent, received_events.append)
     await asyncio.sleep(0.01)
 
     # Now that we are within the wait_for, verify that the subscription is active
@@ -191,7 +191,7 @@ async def test_asyncio_wait_until_any_remote_subscribed_to(
 ):
     client, server_a, server_b, server_c = client_with_three_connections
 
-    asyncio.ensure_future(server_a.subscribe(WaitSubscription, noop))
+    server_a.subscribe(WaitSubscription, noop)
 
     # verify it's not currently subscribed.
     assert not client.is_any_remote_subscribed_to(WaitSubscription)
@@ -217,10 +217,10 @@ async def test_asyncio_wait_until_all_connection_subscribed_to(
 
     assert len(client._full_connections) + len(client._half_connections) == 3
 
-    await server_c.subscribe(WaitSubscription, noop)
+    server_c.subscribe(WaitSubscription, noop)
     assert got_subscription.is_set() is False
-    await server_a.subscribe(WaitSubscription, noop)
+    server_a.subscribe(WaitSubscription, noop)
     assert got_subscription.is_set() is False
-    await server_b.subscribe(WaitSubscription, noop)
+    server_b.subscribe(WaitSubscription, noop)
     await asyncio.sleep(0.01)
     assert got_subscription.is_set() is True

--- a/tests/core/asyncio/test_base_wait_until_any_remote_subscriptions_changed_api.py
+++ b/tests/core/asyncio/test_base_wait_until_any_remote_subscriptions_changed_api.py
@@ -18,7 +18,7 @@ async def test_base_wait_until_any_remote_subscriptions_changed():
             await client.connect_to_endpoint(config)
             assert client.is_connected_to(config.name)
 
-            asyncio.ensure_future(server.subscribe(SubscriptionEvent, lambda e: None))
+            server.subscribe(SubscriptionEvent, lambda e: None)
 
             assert not client.is_any_remote_subscribed_to(SubscriptionEvent)
             await asyncio.wait_for(

--- a/tests/core/asyncio/test_basics.py
+++ b/tests/core/asyncio/test_basics.py
@@ -235,7 +235,7 @@ async def test_exceptions_dont_stop_processing(capsys, endpoint):
     def handle(message):
         the_set.remove(message.item)
 
-    await endpoint.subscribe(RemoveItem, handle)
+    endpoint.subscribe(RemoveItem, handle)
     await endpoint.wait_until_any_remote_subscribed_to(RemoveItem)
 
     # this call should work

--- a/tests/core/asyncio/test_broadcast_config.py
+++ b/tests/core/asyncio/test_broadcast_config.py
@@ -10,11 +10,11 @@ async def test_broadcasts_to_all_endpoints(triplet_of_endpoints):
 
     tracker = Tracker()
 
-    await endpoint1.subscribe(
+    endpoint1.subscribe(
         DummyRequestPair, tracker.track_and_broadcast_dummy(1, endpoint1)
     )
 
-    await endpoint2.subscribe(
+    endpoint2.subscribe(
         DummyRequestPair, tracker.track_and_broadcast_dummy(2, endpoint2)
     )
 
@@ -40,11 +40,11 @@ async def test_broadcasts_to_specific_endpoint(triplet_of_endpoints):
 
     tracker = Tracker()
 
-    await endpoint1.subscribe(
+    endpoint1.subscribe(
         DummyRequestPair, tracker.track_and_broadcast_dummy(1, endpoint1)
     )
 
-    await endpoint2.subscribe(
+    endpoint2.subscribe(
         DummyRequestPair, tracker.track_and_broadcast_dummy(2, endpoint1)
     )
 

--- a/tests/core/asyncio/test_subscription_wait_apis.py
+++ b/tests/core/asyncio/test_subscription_wait_apis.py
@@ -9,7 +9,7 @@ from helpers import DummyRequestPair, DummyResponse
 async def test_wait_until_any_subscribed(triplet_of_endpoints):
     endpoint1, endpoint2, endpoint3 = triplet_of_endpoints
 
-    await endpoint1.subscribe(DummyRequestPair, lambda _: None)
+    endpoint1.subscribe(DummyRequestPair, lambda _: None)
 
     await endpoint3.wait_until_any_remote_subscribed_to(DummyRequestPair)
 
@@ -33,9 +33,9 @@ async def test_wait_until_any_subscribed(triplet_of_endpoints):
 async def test_wait_until_all_subscribed(triplet_of_endpoints):
     endpoint1, endpoint2, endpoint3 = triplet_of_endpoints
 
-    await endpoint1.subscribe(DummyRequestPair, lambda _: None)
+    endpoint1.subscribe(DummyRequestPair, lambda _: None)
 
-    await endpoint2.subscribe(DummyRequestPair, lambda _: None)
+    endpoint2.subscribe(DummyRequestPair, lambda _: None)
 
     await endpoint3.wait_until_all_remotes_subscribed_to(DummyRequestPair)
 
@@ -60,7 +60,7 @@ async def test_wait_until_all_subscribed(triplet_of_endpoints):
 async def test_wait_until_specific_subscribed(triplet_of_endpoints):
     endpoint1, endpoint2, endpoint3 = triplet_of_endpoints
 
-    await endpoint1.subscribe(DummyRequestPair, lambda _: None)
+    endpoint1.subscribe(DummyRequestPair, lambda _: None)
 
     await endpoint3.wait_until_remote_subscribed_to(endpoint1.name, DummyRequestPair)
 


### PR DESCRIPTION
## What was wrong?

This is an alternative to #105 that makes the `subscribe` API synchronous. The only reason **not to do this** that I'm aware of would be that the `TrioEndpoint` may not be able to have a synchronous `subscribe`?

## How was it fixed?

Nothing changes about it's implementation. Just dropping the `async` in the function definition.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2015/02/zao-fox-village-japan-5.jpg)
