### PR TITLE
Ensure local use of endpoint works

### DIFF
--- a/lahja/base.py
+++ b/lahja/base.py
@@ -128,10 +128,6 @@ class RemoteEndpointAPI(ABC):
         ...
 
     @abstractmethod
-    def can_send_item(self, item: BaseEvent, config: Optional[BroadcastConfig]) -> bool:
-        ...
-
-    @abstractmethod
     async def send_message(self, message: Msg) -> None:
         ...
 
@@ -291,16 +287,6 @@ class BaseRemoteEndpoint(RemoteEndpointAPI):
                     return
                 if block:
                     await self._received_response.wait()
-
-    def can_send_item(self, item: BaseEvent, config: Optional[BroadcastConfig]) -> bool:
-        if config is not None:
-            if self.name is not None and not config.allowed_to_receive(self.name):
-                return False
-            elif config.filter_event_id is not None:
-                # the item is a response to a request.
-                return True
-
-        return type(item) in self._subscribed_events
 
     async def send_message(self, message: Msg) -> None:
         await self.conn.send_message(message)

--- a/lahja/common.py
+++ b/lahja/common.py
@@ -165,3 +165,19 @@ class RequestIDGenerator(Iterator[RequestID]):
 
     def __next__(self) -> RequestID:
         return self._base + next(self._counter).to_bytes(4, "little")  # type: ignore
+
+
+def should_endpoint_receive_item(
+    item: BaseEvent,
+    config: Optional[BroadcastConfig],
+    endpoint_name: str,
+    subscribed_events: Set[Type[BaseEvent]],
+) -> bool:
+    if config is not None:
+        if not config.allowed_to_receive(endpoint_name):
+            return False
+        elif config.filter_event_id is not None:
+            # the item is a response to a request.
+            return True
+
+    return type(item) in subscribed_events

--- a/tests/core/asyncio/conftest.py
+++ b/tests/core/asyncio/conftest.py
@@ -21,6 +21,12 @@ def server_config(unique_name, ipc_base_path):
 
 
 @pytest.fixture
+async def endpoint():
+    async with AsyncioEndpoint(generate_unique_name()).run() as endpoint:
+        yield endpoint
+
+
+@pytest.fixture
 async def endpoint_server(server_config):
     async with AsyncioEndpoint.serve(server_config) as server:
         yield server

--- a/tests/core/asyncio/test_connect.py
+++ b/tests/core/asyncio/test_connect.py
@@ -7,45 +7,45 @@ from lahja import AsyncioEndpoint, ConnectionAttemptRejected, ConnectionConfig
 
 
 @pytest.mark.asyncio
-async def test_connect_to_endpoint():
+async def test_connect_to_endpoint(endpoint):
     config = ConnectionConfig.from_name(generate_unique_name())
     async with AsyncioEndpoint.serve(config):
-        async with AsyncioEndpoint("client").run() as client:
-            await client.connect_to_endpoint(config)
-            assert client.is_connected_to(config.name)
+        await endpoint.connect_to_endpoint(config)
+        assert endpoint.is_connected_to(config.name)
 
 
 @pytest.mark.asyncio
-async def test_wait_until_connected_to():
+async def test_wait_until_connected_to(endpoint):
     config = ConnectionConfig.from_name(generate_unique_name())
     async with AsyncioEndpoint.serve(config):
-        async with AsyncioEndpoint("client").run() as client:
-            asyncio.ensure_future(client.connect_to_endpoint(config))
+        asyncio.ensure_future(endpoint.connect_to_endpoint(config))
 
-            assert not client.is_connected_to(config.name)
-            await client.wait_until_connected_to(config.name)
-            assert client.is_connected_to(config.name)
+        assert not endpoint.is_connected_to(config.name)
+        await endpoint.wait_until_connected_to(config.name)
+        assert endpoint.is_connected_to(config.name)
 
 
 @pytest.mark.asyncio
-async def test_server_establishes_reverse_connection():
+async def test_server_establishes_reverse_connection(endpoint):
     config = ConnectionConfig.from_name(generate_unique_name())
     async with AsyncioEndpoint.serve(config) as server:
-        async with AsyncioEndpoint("client").run() as client:
-            await client.connect_to_endpoint(config)
-            assert client.is_connected_to(config.name)
-            await asyncio.wait_for(
-                server.wait_until_connected_to(client.name), timeout=4
-            )
+        await endpoint.connect_to_endpoint(config)
+        assert endpoint.is_connected_to(config.name)
+        assert server.is_connected_to(endpoint.name)
 
 
 @pytest.mark.asyncio
-async def test_rejects_duplicates_when_connecting():
+async def test_rejects_duplicates_when_connecting(endpoint):
     config = ConnectionConfig.from_name(generate_unique_name())
     async with AsyncioEndpoint.serve(config):
-        async with AsyncioEndpoint("client").run() as client:
-            await client.connect_to_endpoint(config)
+        await endpoint.connect_to_endpoint(config)
 
-            assert client.is_connected_to(config.name)
-            with pytest.raises(ConnectionAttemptRejected):
-                await client.connect_to_endpoint(config)
+        assert endpoint.is_connected_to(config.name)
+        with pytest.raises(ConnectionAttemptRejected):
+            await endpoint.connect_to_endpoint(config)
+
+
+@pytest.mark.asyncio
+async def test_endpoint_rejects_self_connection(endpoint_server, server_config):
+    with pytest.raises(ConnectionAttemptRejected):
+        await endpoint_server.connect_to_endpoint(server_config)

--- a/tests/core/asyncio/test_endpoint_local_broadcast.py
+++ b/tests/core/asyncio/test_endpoint_local_broadcast.py
@@ -1,0 +1,97 @@
+import asyncio
+
+import pytest
+
+from lahja import BaseEvent, BaseRequestResponseEvent
+
+
+class BroadcastEvent(BaseEvent):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_subscribe_and_broadcast_to_self(endpoint):
+    got_event = asyncio.Event()
+
+    endpoint.subscribe(BroadcastEvent, lambda ev: got_event.set())
+
+    assert not got_event.is_set()
+    await endpoint.broadcast(BroadcastEvent())
+
+    await asyncio.wait_for(got_event.wait(), timeout=0.1)
+    assert got_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_and_broadcast_to_self(endpoint):
+    ready = asyncio.Event()
+    got_event = asyncio.Event()
+
+    async def do_wait_for():
+        ready.set()
+        await endpoint.wait_for(BroadcastEvent)
+        got_event.set()
+
+    asyncio.ensure_future(do_wait_for())
+    await ready.wait()
+
+    assert not got_event.is_set()
+    await endpoint.broadcast(BroadcastEvent())
+
+    await asyncio.wait_for(got_event.wait(), timeout=0.1)
+    assert got_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_stream_and_broadcast_to_self(endpoint):
+    ready = asyncio.Event()
+    finished_stream = asyncio.Event()
+
+    async def do_stream():
+        ready.set()
+        async for ev in endpoint.stream(BroadcastEvent, num_events=3):
+            pass
+
+        finished_stream.set()
+
+    asyncio.ensure_future(do_stream())
+    await ready.wait()
+
+    assert not finished_stream.is_set()
+    await endpoint.broadcast(BroadcastEvent())
+    await endpoint.broadcast(BroadcastEvent())
+    await endpoint.broadcast(BroadcastEvent())
+
+    await asyncio.wait_for(finished_stream.wait(), timeout=0.1)
+    assert finished_stream.is_set()
+
+
+class Response(BaseEvent):
+    def __init__(self, value):
+        self.value = value
+
+
+class Request(BaseRequestResponseEvent[Response]):
+    @staticmethod
+    def expected_response_type():
+        return Response
+
+    def __init__(self, value):
+        self.value = value
+
+
+@pytest.mark.asyncio
+async def test_request_response_and_broadcast_to_self(endpoint):
+    ready = asyncio.Event()
+
+    async def do_response():
+        ready.set()
+        req = await endpoint.wait_for(Request)
+        await endpoint.broadcast(Response(req.value), req.broadcast_config())
+
+    asyncio.ensure_future(do_response())
+    await ready.wait()
+
+    resp = await asyncio.wait_for(endpoint.request(Request("test")), timeout=0.1)
+    assert isinstance(resp, Response)
+    assert resp.value == "test"


### PR DESCRIPTION
## What was wrong?

We need the ability for an endpoint to consume events from itself (as if it were connected).

## How was it fixed?

This is a *partial* fix since it's unclear what to do about the varios `wait_until` and `is_connected` APIs.

This ensures that all of the primary event base APIs on an endpoint work as expected for local consumption of events.

#### Cute Animal Picture

![6f7f7d937161bd52f5638bd7ed9bc8ed](https://user-images.githubusercontent.com/824194/59051314-cf18a600-8849-11e9-8b52-189564e437b1.jpg)
