### PR TITLE
Flesh out self-wait-subscribe APIs

### DIFF
--- a/tests/core/asyncio/test_endpoint_local_broadcast.py
+++ b/tests/core/asyncio/test_endpoint_local_broadcast.py
@@ -11,6 +11,8 @@ class BroadcastEvent(BaseEvent):
 
 @pytest.mark.asyncio
 async def test_subscribe_and_broadcast_to_self(endpoint):
+    endpoint.enable_local_broadcast()
+
     got_event = asyncio.Event()
 
     endpoint.subscribe(BroadcastEvent, lambda ev: got_event.set())
@@ -24,6 +26,8 @@ async def test_subscribe_and_broadcast_to_self(endpoint):
 
 @pytest.mark.asyncio
 async def test_wait_for_and_broadcast_to_self(endpoint):
+    endpoint.enable_local_broadcast()
+
     ready = asyncio.Event()
     got_event = asyncio.Event()
 
@@ -44,6 +48,8 @@ async def test_wait_for_and_broadcast_to_self(endpoint):
 
 @pytest.mark.asyncio
 async def test_stream_and_broadcast_to_self(endpoint):
+    endpoint.enable_local_broadcast()
+
     ready = asyncio.Event()
     finished_stream = asyncio.Event()
 
@@ -82,6 +88,8 @@ class Request(BaseRequestResponseEvent[Response]):
 
 @pytest.mark.asyncio
 async def test_request_response_and_broadcast_to_self(endpoint):
+    endpoint.enable_local_broadcast()
+
     ready = asyncio.Event()
 
     async def do_response():

--- a/tests/core/asyncio/test_local_broadcast_endpoint.py
+++ b/tests/core/asyncio/test_local_broadcast_endpoint.py
@@ -1,0 +1,164 @@
+import asyncio
+
+import pytest
+
+from lahja import BaseEvent
+
+
+@pytest.mark.asyncio
+async def test_local_broadcast_is_connected_to_self(endpoint):
+    assert not endpoint.is_connected_to(endpoint.name)
+    endpoint.enable_local_broadcast()
+    assert endpoint.is_connected_to(endpoint.name)
+
+
+@pytest.mark.asyncio
+async def test_local_broadcast_wait_until_connected_to(endpoint):
+    ready = asyncio.Event()
+
+    async def do_enable():
+        await ready.wait()
+        endpoint.enable_local_broadcast()
+
+    asyncio.ensure_future(do_enable())
+
+    assert not endpoint.is_connected_to(endpoint.name)
+
+    ready.set()
+    await endpoint.wait_until_connected_to(endpoint.name)
+    assert endpoint.is_connected_to(endpoint.name)
+
+
+@pytest.mark.asyncio
+async def test_local_broadcast_result_in_being_present_in_remotes(endpoint):
+    before_names = set(
+        name for name, _ in endpoint.get_connected_endpoints_and_subscriptions()
+    )
+    assert endpoint.name not in before_names
+
+    endpoint.enable_local_broadcast()
+
+    after_names = set(
+        name for name, _ in endpoint.get_connected_endpoints_and_subscriptions()
+    )
+    assert endpoint.name in after_names
+
+
+class Event(BaseEvent):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_local_broadcast_wait_until_remote_subscriptions_change(endpoint):
+    ready = asyncio.Event()
+    done = asyncio.Event()
+
+    async def do_wait():
+        ready.set()
+        await endpoint.wait_until_remote_subscriptions_change()
+        done.set()
+
+    asyncio.ensure_future(do_wait())
+
+    await ready.wait()
+    assert not done.is_set()
+    endpoint.enable_local_broadcast()
+    await done.wait()
+
+
+@pytest.mark.asyncio
+async def test_local_broadcast_wait_until_any_subscribed_to(endpoint):
+    ready = asyncio.Event()
+
+    async def do_enable():
+        await ready.wait()
+        endpoint.enable_local_broadcast()
+
+    asyncio.ensure_future(do_enable())
+
+    endpoint.subscribe(Event, lambda ev: None)
+
+    assert not endpoint.is_any_remote_subscribed_to(Event)
+
+    ready.set()
+    await asyncio.wait_for(
+        endpoint.wait_until_any_remote_subscribed_to(Event), timeout=0.01
+    )
+    assert endpoint.is_any_remote_subscribed_to(Event)
+
+
+@pytest.mark.asyncio
+async def test_local_broadcast_is_any_remote_subscribed(endpoint_pair):
+    alice, bob = endpoint_pair
+
+    assert not alice.is_any_remote_subscribed_to(Event)
+    assert not bob.is_any_remote_subscribed_to(Event)
+
+    alice.subscribe(Event, lambda ev: None)
+
+    await bob.wait_until_remote_subscribed_to(alice.name, Event)
+
+    assert not alice.is_any_remote_subscribed_to(Event)
+    assert bob.is_any_remote_subscribed_to(Event)
+
+    alice.enable_local_broadcast()
+
+    assert alice.is_any_remote_subscribed_to(Event)
+    assert bob.is_any_remote_subscribed_to(Event)
+
+
+@pytest.mark.asyncio
+async def test_local_broadcast_are_all_remotes_subscribed(endpoint_pair):
+    alice, bob = endpoint_pair
+
+    assert not alice.are_all_remotes_subscribed_to(Event)
+    assert not bob.are_all_remotes_subscribed_to(Event)
+
+    bob.subscribe(Event, lambda ev: None)
+
+    await alice.wait_until_remote_subscribed_to(bob.name, Event)
+
+    assert alice.are_all_remotes_subscribed_to(Event)
+    assert not bob.are_all_remotes_subscribed_to(Event)
+
+    alice.enable_local_broadcast()
+
+    assert not alice.are_all_remotes_subscribed_to(Event)
+    assert not bob.are_all_remotes_subscribed_to(Event)
+
+    alice.subscribe(Event, lambda ev: None)
+    await bob.wait_until_remote_subscribed_to(alice.name, Event)
+
+    assert alice.are_all_remotes_subscribed_to(Event)
+    assert bob.are_all_remotes_subscribed_to(Event)
+
+
+@pytest.mark.asyncio
+async def test_local_broadcast_is_remote_subscribed_to(endpoint):
+    assert not endpoint.is_remote_subscribed_to(endpoint.name, Event)
+
+    endpoint.subscribe(Event, lambda ev: None)
+
+    assert not endpoint.is_remote_subscribed_to(endpoint.name, Event)
+
+    endpoint.enable_local_broadcast()
+
+    assert endpoint.is_remote_subscribed_to(endpoint.name, Event)
+
+
+@pytest.mark.asyncio
+async def test_local_broadcast_enables_local_broadcast(endpoint):
+    did_handle = asyncio.Event()
+
+    endpoint.subscribe(Event, lambda ev: did_handle.set())
+
+    # broadcast a few
+    await endpoint.broadcast(Event())
+    await endpoint.broadcast(Event())
+    await endpoint.broadcast(Event())
+    assert not did_handle.is_set()
+
+    endpoint.enable_local_broadcast()
+
+    await endpoint.broadcast(Event())
+    assert did_handle.is_set()


### PR DESCRIPTION
## What was wrong?

I got in a hurry and didn't take into account that this needed to be sorted out.

The various APIs for *waiting* on subscriptions, checking subscriptions, waiting on connections and checking connections don't always behave in intuitive ways when dealing with a singular endpoint as if it was two endpoints which is a feature that we want to support.

## How was it fixed?

I don't think there was *one* correct behavior here, at least not by default.  Before the revers connections change, you did have to manually connect an endpoint to itself for this to work.  This is now replaced by a call to `EndpointAPI.enable_local_broadcast()`

Once this has been enabled, the endpoint will treat itself exactly as if it was another connected remote.  This includes triggering all of the correct `wait_` apis.

Comparing this to the previous state of affairs prior to reverse connections, I believe it is functionally equivalent. In previous code, if you simply replaced `endpoint.connect_to_endpoint(config_for_self)` with `endpoint.enable_local_broadcast()` I believe that the functionality would be identical.

#### Cute Animal Picture

![PKTVTD0](https://user-images.githubusercontent.com/824194/59071011-2f274080-887a-11e9-980a-e2399e357e55.jpg)

