### PR TITLE
Self subscribe API with auto-opt-in

### DIFF
--- a/examples/inter_process_ping_pong.py
+++ b/examples/inter_process_ping_pong.py
@@ -43,7 +43,7 @@ async def proc1_worker():
                 "Received via SUBSCRIBE API in proc1: %s", event.payload
             ),
         )
-        await server.wait_until_any_remote_subscribed_to(FirstThingHappened)
+        await server.wait_until_any_endpoint_subscribed_to(FirstThingHappened)
 
         while True:
             logging.info("Hello from proc1")
@@ -69,7 +69,7 @@ async def proc2_worker():
                 "Received via SUBSCRIBE API in proc2: %s", event.payload
             ),
         )
-        await client.wait_until_any_remote_subscribed_to(SecondThingHappened)
+        await client.wait_until_any_endpoint_subscribed_to(SecondThingHappened)
 
         while True:
             logging.info("Hello from proc2")

--- a/examples/request_api.py
+++ b/examples/request_api.py
@@ -47,7 +47,7 @@ async def proc2_worker():
     config = ConnectionConfig.from_name("e1")
     async with AsyncioEndpoint("e2").run() as client:
         await client.connect_to_endpoints(config)
-        await client.wait_until_any_remote_subscribed_to(GetSomethingRequest)
+        await client.wait_until_any_endpoint_subscribed_to(GetSomethingRequest)
 
         for i in range(3):
             print("Requesting")

--- a/lahja/tools/benchmark/process.py
+++ b/lahja/tools/benchmark/process.py
@@ -92,7 +92,7 @@ class BroadcastDriver(BaseDriverProcess):
     @staticmethod
     async def do_driver(event_bus: BaseEndpoint, config: DriverProcessConfig) -> None:
         for consumer in config.connected_endpoints:
-            await event_bus.wait_until_remote_subscribed_to(
+            await event_bus.wait_until_endpoint_subscribed_to(
                 consumer.name, PerfMeasureEvent
             )
 
@@ -111,7 +111,7 @@ class RequestDriver(BaseDriverProcess):
         cls, event_bus: BaseEndpoint, config: DriverProcessConfig
     ) -> None:
         for consumer in config.connected_endpoints:
-            await event_bus.wait_until_remote_subscribed_to(
+            await event_bus.wait_until_endpoint_subscribed_to(
                 consumer.name, PerfMeasureRequest
             )
 
@@ -161,7 +161,7 @@ class BaseConsumerProcess(ABC):
             await event_bus.wait_until_connected_to(DRIVER_ENDPOINT)
             stats = await cls.do_consumer(event_bus, config)
 
-            await event_bus.wait_until_remote_subscribed_to(
+            await event_bus.wait_until_endpoint_subscribed_to(
                 REPORTER_ENDPOINT, TotalRecordedEvent
             )
 

--- a/tests/core/asyncio/test_base_wait_until_any_remote_subscriptions_changed_api.py
+++ b/tests/core/asyncio/test_base_wait_until_any_remote_subscriptions_changed_api.py
@@ -11,7 +11,7 @@ class SubscriptionEvent(BaseEvent):
 
 
 @pytest.mark.asyncio
-async def test_base_wait_until_any_remote_subscriptions_changed():
+async def test_base_wait_until_any_endpoint_subscriptions_changed():
     config = ConnectionConfig.from_name(generate_unique_name())
     async with AsyncioEndpoint.serve(config) as server:
         async with AsyncioEndpoint("client").run() as client:
@@ -20,8 +20,8 @@ async def test_base_wait_until_any_remote_subscriptions_changed():
 
             server.subscribe(SubscriptionEvent, lambda e: None)
 
-            assert not client.is_any_remote_subscribed_to(SubscriptionEvent)
+            assert not client.is_any_endpoint_subscribed_to(SubscriptionEvent)
             await asyncio.wait_for(
-                client.wait_until_remote_subscriptions_change(), timeout=0.1
+                client.wait_until_endpoint_subscriptions_change(), timeout=0.1
             )
-            assert client.is_any_remote_subscribed_to(SubscriptionEvent)
+            assert client.is_any_endpoint_subscribed_to(SubscriptionEvent)

--- a/tests/core/asyncio/test_basics.py
+++ b/tests/core/asyncio/test_basics.py
@@ -35,7 +35,7 @@ async def test_request_response(endpoint_pair, event_loop):
         await alice.broadcast(Response(req.value), req.broadcast_config())
 
     asyncio.ensure_future(do_serve_response())
-    await bob.wait_until_any_remote_subscribed_to(Request)
+    await bob.wait_until_any_endpoint_subscribed_to(Request)
 
     response = await bob.request(Request("test-request"))
     assert isinstance(response, Response)
@@ -68,7 +68,7 @@ async def test_response_must_match(endpoint_pair):
 
     asyncio.ensure_future(do_serve_wrong_response())
 
-    await bob.wait_until_any_remote_subscribed_to(Request)
+    await bob.wait_until_any_endpoint_subscribed_to(Request)
 
     with pytest.raises(UnexpectedResponse):
         await bob.request(Request("test-wrong-response"))
@@ -93,7 +93,7 @@ async def test_stream_with_break(endpoint_pair):
                 break
 
     asyncio.ensure_future(stream_response())
-    await bob.wait_until_any_remote_subscribed_to(SimpleEvent)
+    await bob.wait_until_any_endpoint_subscribed_to(SimpleEvent)
 
     # we broadcast one more item than what we consume and test for that
     for i in range(5):
@@ -117,7 +117,7 @@ async def test_stream_with_num_events(endpoint_pair):
             stream_counter += 1
 
     asyncio.ensure_future(stream_response())
-    await bob.wait_until_any_remote_subscribed_to(SimpleEvent)
+    await bob.wait_until_any_endpoint_subscribed_to(SimpleEvent)
 
     # we broadcast one more item than what we consume and test for that
     for i in range(3):
@@ -151,7 +151,7 @@ async def test_stream_can_get_cancelled(endpoint_pair):
 
     stream_coro = asyncio.ensure_future(stream_response())
     cancel_coro = asyncio.ensure_future(cancel_soon())
-    await bob.wait_until_any_remote_subscribed_to(SimpleEvent)
+    await bob.wait_until_any_endpoint_subscribed_to(SimpleEvent)
 
     for i in range(50):
         await bob.broadcast(SimpleEvent())
@@ -179,7 +179,7 @@ async def test_stream_cancels_when_parent_task_is_cancelled(endpoint_pair):
             await asyncio.sleep(0.01)
 
     task = asyncio.ensure_future(stream_response())
-    await bob.wait_until_any_remote_subscribed_to(SimpleEvent)
+    await bob.wait_until_any_endpoint_subscribed_to(SimpleEvent)
 
     async def cancel_soon():
         while True:
@@ -211,7 +211,7 @@ async def test_wait_for(endpoint_pair):
         received = request
 
     asyncio.ensure_future(stream_response())
-    await bob.wait_until_any_remote_subscribed_to(SimpleEvent)
+    await bob.wait_until_any_endpoint_subscribed_to(SimpleEvent)
     await bob.broadcast(SimpleEvent())
 
     await asyncio.sleep(0.01)
@@ -246,7 +246,7 @@ async def test_exceptions_dont_stop_processing(caplog, endpoint_pair):
         the_set.remove(message.item)
 
     bob.subscribe(RemoveItem, handle)
-    await alice.wait_until_any_remote_subscribed_to(RemoveItem)
+    await alice.wait_until_any_endpoint_subscribed_to(RemoveItem)
 
     # this call should work
     caplog.clear()

--- a/tests/core/asyncio/test_broadcast_config.py
+++ b/tests/core/asyncio/test_broadcast_config.py
@@ -18,7 +18,10 @@ async def test_broadcasts_to_all_endpoints(server_with_two_clients):
     client_a.subscribe(BroadcastEvent, return_queue.put_nowait)
     client_b.subscribe(BroadcastEvent, return_queue.put_nowait)
 
-    await server.wait_until_all_remotes_subscribed_to(BroadcastEvent)
+    await server.wait_until_all_endpoints_subscribed_to(
+        BroadcastEvent, exclude_self=True
+    )
+
     await server.broadcast(BroadcastEvent())
 
     result_a = await asyncio.wait_for(return_queue.get(), timeout=0.1)
@@ -44,8 +47,10 @@ async def test_broadcasts_to_specific_endpoint(server_with_two_clients):
     client_a.subscribe(TailEvent, return_queue.put_nowait)
     client_b.subscribe(TailEvent, return_queue.put_nowait)
 
-    await server.wait_until_all_remotes_subscribed_to(BroadcastEvent)
-    await server.wait_until_all_remotes_subscribed_to(TailEvent)
+    await server.wait_until_all_endpoints_subscribed_to(
+        BroadcastEvent, exclude_self=True
+    )
+    await server.wait_until_all_endpoints_subscribed_to(TailEvent, exclude_self=True)
 
     # broadcast once targeted at a specific endpoint
     await server.broadcast(
@@ -100,7 +105,8 @@ async def test_request_to_specific_endpoint(server_with_two_clients):
     asyncio.ensure_future(handler_b())
 
     await asyncio.wait_for(
-        server.wait_until_all_remotes_subscribed_to(Request), timeout=0.1
+        server.wait_until_all_endpoints_subscribed_to(Request, exclude_self=True),
+        timeout=0.1,
     )
 
     response_a = await asyncio.wait_for(

--- a/tests/core/asyncio/test_internal.py
+++ b/tests/core/asyncio/test_internal.py
@@ -24,8 +24,8 @@ async def test_internal_propagation(endpoint_pair):
     will_not_finish = asyncio.ensure_future(do_wait_for(endpoint_b, got_by_endpoint_b))
 
     # give subscriptions time to update
-    await endpoint_a.wait_until_all_remotes_subscribed_to(Internal)
-    await endpoint_b.wait_until_all_remotes_subscribed_to(Internal)
+    await endpoint_a.wait_until_all_endpoints_subscribed_to(Internal)
+    await endpoint_b.wait_until_all_endpoints_subscribed_to(Internal)
 
     # now broadcast a few over the internal bus on `A`
     for _ in range(5):


### PR DESCRIPTION
## What was wrong?

I got in a hurry and didn't take into account that this needed to be sorted out.

The various APIs for *waiting* on subscriptions, checking subscriptions, waiting on connections and checking connections don't always behave in intuitive ways when dealing with a singular endpoint as if it was two endpoints which is a feature that we want to support.

## How was it fixed?

Endpoints now treat themselves as a connected endpoint.  All of the various *wait* APIs will treat *self* as part of the set of connected endpoints.

This also results in renaming some of the APIs that previously used the term *remote* to instead use *endpoint* since it is inconsistent to refer to ourselves as a remote.

The only exception is the `wait_until_all_endpoints_subscribed` and `are_all_endgoints_subscribed` which each take an optional extra parameter `exclude_self` which defaults to `False`.

#### Cute Animal Picture

![PKTVTD0](https://user-images.githubusercontent.com/824194/59071011-2f274080-887a-11e9-980a-e2399e357e55.jpg)

