### PR TITLE
Change `exclude_self` parm to `include_self`

### DIFF
--- a/lahja/base.py
+++ b/lahja/base.py
@@ -532,7 +532,7 @@ class EndpointAPI(ABC):
 
     @abstractmethod
     async def wait_until_all_endpoints_subscribed_to(
-        self, event: Type[BaseEvent], *, exclude_self: bool = False
+        self, event: Type[BaseEvent], *, include_self: bool = True
     ) -> None:
         """
         Block until all currently connected remote endpoints are subscribed to the specified
@@ -669,14 +669,14 @@ class BaseEndpoint(EndpointAPI):
         return False
 
     def are_all_endpoints_subscribed_to(
-        self, event_type: Type[BaseEvent], exclude_self: bool = False
+        self, event_type: Type[BaseEvent], include_self: bool = True
     ) -> bool:
         """
         Return ``True`` if every connected remote endpoint is subscribed to the specified event
         type from this endpoint. Otherwise return ``False``.
         """
         for endpoint, subscriptions in self.get_connected_endpoints_and_subscriptions():
-            if exclude_self and endpoint == self.name:
+            if not include_self and endpoint == self.name:
                 continue
 
             if event_type not in subscriptions:
@@ -711,7 +711,7 @@ class BaseEndpoint(EndpointAPI):
                 await self._remote_subscriptions_changed.wait()
 
     async def wait_until_all_endpoints_subscribed_to(
-        self, event: Type[BaseEvent], *, exclude_self: bool = False
+        self, event: Type[BaseEvent], *, include_self: bool = True
     ) -> None:
         """
         Block until all currently connected remote endpoints are subscribed to the specified
@@ -720,7 +720,7 @@ class BaseEndpoint(EndpointAPI):
         async with self._remote_subscriptions_changed:
             while True:
                 if self.are_all_endpoints_subscribed_to(
-                    event, exclude_self=exclude_self
+                    event, include_self=include_self
                 ):
                     return
                 await self._remote_subscriptions_changed.wait()

--- a/tests/core/asyncio/test_asyncio_subscriptions_api.py
+++ b/tests/core/asyncio/test_asyncio_subscriptions_api.py
@@ -234,10 +234,10 @@ async def test_asyncio_wait_until_all_connection_subscribed_to(
     await asyncio.sleep(0.01)
     assert got_subscription.is_set() is False
 
-    assert client.are_all_endpoints_subscribed_to(WaitSubscription, exclude_self=True)
+    assert client.are_all_endpoints_subscribed_to(WaitSubscription, include_self=False)
     # test both default and explicit argument
     assert not client.are_all_endpoints_subscribed_to(
-        WaitSubscription, exclude_self=False
+        WaitSubscription, include_self=True
     )
     assert not client.are_all_endpoints_subscribed_to(WaitSubscription)
 

--- a/tests/core/asyncio/test_broadcast_config.py
+++ b/tests/core/asyncio/test_broadcast_config.py
@@ -19,7 +19,7 @@ async def test_broadcasts_to_all_endpoints(server_with_two_clients):
     client_b.subscribe(BroadcastEvent, return_queue.put_nowait)
 
     await server.wait_until_all_endpoints_subscribed_to(
-        BroadcastEvent, exclude_self=True
+        BroadcastEvent, include_self=False
     )
 
     await server.broadcast(BroadcastEvent())
@@ -48,9 +48,9 @@ async def test_broadcasts_to_specific_endpoint(server_with_two_clients):
     client_b.subscribe(TailEvent, return_queue.put_nowait)
 
     await server.wait_until_all_endpoints_subscribed_to(
-        BroadcastEvent, exclude_self=True
+        BroadcastEvent, include_self=False
     )
-    await server.wait_until_all_endpoints_subscribed_to(TailEvent, exclude_self=True)
+    await server.wait_until_all_endpoints_subscribed_to(TailEvent, include_self=False)
 
     # broadcast once targeted at a specific endpoint
     await server.broadcast(
@@ -105,7 +105,7 @@ async def test_request_to_specific_endpoint(server_with_two_clients):
     asyncio.ensure_future(handler_b())
 
     await asyncio.wait_for(
-        server.wait_until_all_endpoints_subscribed_to(Request, exclude_self=True),
+        server.wait_until_all_endpoints_subscribed_to(Request, include_self=False),
         timeout=0.1,
     )
 


### PR DESCRIPTION
## What was wrong?



Negative bool flags lead to double negative checks
that are more error prone, like: `if not exclude_self`

## How was it fixed?

Changed `exclude_self` param that defaulted to `False` to `include_self` param that defaults to `True`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.redd.it/vkecec8t5ep01.jpg)
