### PR TITLE
Ignore .pytest_cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ chains
 
 # tox/pytest cache
 .cache
+.pytest_cache
 
 # Test output logs
 logs


### PR DESCRIPTION
## What was wrong?

The `.pytest_cache` directory was not on the `gitignore` file.

## How was it fixed?

Added it

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2015/02/zao-fox-village-japan-fb__700.jpg)
