### PR TITLE
Trio base endpoint implementation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,12 +69,24 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-core-asyncio
+  py36-core-trio:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-core-trio
   py37-core-asyncio:
     <<: *common
     docker:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core-asyncio
+  py37-core-trio:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-core-trio
   py36-examples:
     <<: *common
     docker:
@@ -93,12 +105,24 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-snappy-core-asyncio
+  py36-snappy-core-trio:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-snappy-core-trio
   py37-snappy-core-asyncio:
     <<: *common
     docker:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-snappy-core-asyncio
+  py37-snappy-core-trio:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-snappy-core-trio
 workflows:
   version: 2
   test:
@@ -108,8 +132,12 @@ workflows:
       - doctest
       - lint
       - py36-core-asyncio
-      - py37-core-asyncio
+      - py36-core-trio
       - py36-examples
       - py37-examples
+      - py37-core-asyncio
+      - py37-core-trio
       - py36-snappy-core-asyncio
+      - py36-snappy-core-trio
       - py37-snappy-core-asyncio
+      - py37-snappy-core-trio

--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -51,7 +51,6 @@ from lahja.common import (
     ConnectionConfig,
     Message,
     Msg,
-    RequestIDGenerator,
     Subscription,
     should_endpoint_receive_item,
 )
@@ -199,19 +198,11 @@ class AsyncioEndpoint(BaseEndpoint):
     _sync_handler: DefaultDict[Type[BaseEvent], List[SubscriptionSyncHandler]]
 
     _loop: Optional[asyncio.AbstractEventLoop] = None
-    _get_request_id: Iterator[RequestID]
 
     _subscriptions_changed: asyncio.Event
 
     def __init__(self, name: str) -> None:
         super().__init__(name)
-
-        try:
-            self._get_request_id = RequestIDGenerator(name.encode("ascii") + b":")
-        except UnicodeDecodeError:
-            raise Exception(
-                f"TODO: Invalid endpoint name: '{name}'. Must be ASCII encodable string"
-            )
 
         # Signal when a new remote connection is established
         self._remote_connections_changed = asyncio.Condition()  # type: ignore

--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -153,7 +153,7 @@ class AsyncioRemoteEndpoint(BaseRemoteEndpoint):
     #
     # Running API
     #
-    @asynccontextmanager  # type: ignore
+    @asynccontextmanager
     async def run(self) -> AsyncIterator[RemoteEndpointAPI]:
         await self._start()
 
@@ -284,7 +284,7 @@ class AsyncioEndpoint(BaseEndpoint):
     #
     # Running API
     #
-    @asynccontextmanager  # type: ignore
+    @asynccontextmanager
     async def run(self) -> AsyncIterator[EndpointAPI]:
         if not self._loop:
             self._loop = asyncio.get_event_loop()
@@ -421,7 +421,7 @@ class AsyncioEndpoint(BaseEndpoint):
     # Server API
     #
     @classmethod
-    @asynccontextmanager  # type: ignore
+    @asynccontextmanager
     async def serve(cls, config: ConnectionConfig) -> AsyncIterator["AsyncioEndpoint"]:
         endpoint = cls(config.name)
         async with endpoint.run():

--- a/lahja/exceptions.py
+++ b/lahja/exceptions.py
@@ -12,6 +12,16 @@ class BindError(LahjaError):
     """
 
 
+class LifecycleError(LahjaError):
+    """
+    Raised when attempting to violate the lifecycle of an endpoint such as
+    starting an already started endpoint or starting an endpoint that has
+    already stopped.
+    """
+
+    pass
+
+
 class ConnectionAttemptRejected(LahjaError):
     """
     Raised when an attempt was made to connect to an endpoint that is already connected.

--- a/lahja/tools/benchmark/backends.py
+++ b/lahja/tools/benchmark/backends.py
@@ -3,6 +3,7 @@ from typing import Any, Type
 
 from lahja.asyncio import AsyncioEndpoint
 from lahja.base import BaseEndpoint
+from lahja.trio import TrioEndpoint
 
 
 class BaseBackend(ABC):
@@ -40,3 +41,23 @@ class AsyncioBackend(BaseBackend):
         import asyncio
 
         await asyncio.sleep(seconds)
+
+
+class TrioBackend(BaseBackend):
+    name = "trio"
+    Endpoint = TrioEndpoint
+
+    @staticmethod
+    def run(coro: Any, *args: Any) -> None:
+        # UNCOMMENT FOR DEBUGGING
+        # logger = multiprocessing.log_to_stderr()
+        # logger.setLevel(logging.INFO)
+        import trio
+
+        trio.run(coro, *args)
+
+    @staticmethod
+    async def sleep(seconds: float) -> None:
+        import trio
+
+        await trio.sleep(seconds)

--- a/lahja/trio/__init__.py
+++ b/lahja/trio/__init__.py
@@ -1,0 +1,1 @@
+from .endpoint import TrioEndpoint  # noqa: F401

--- a/lahja/trio/endpoint.py
+++ b/lahja/trio/endpoint.py
@@ -1,0 +1,807 @@
+import asyncio
+import collections
+import itertools
+import logging
+import pathlib
+import pickle
+from typing import (
+    Any,
+    AsyncGenerator,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    DefaultDict,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
+
+from async_generator import asynccontextmanager
+import trio
+import trio_typing
+
+from lahja import constants
+from lahja.base import (
+    BaseEndpoint,
+    BaseRemoteEndpoint,
+    ConnectionAPI,
+    EndpointAPI,
+    RemoteEndpointAPI,
+    TResponse,
+    TStreamEvent,
+    TSubscribeEvent,
+)
+from lahja.common import (
+    BaseEvent,
+    BaseRequestResponseEvent,
+    Broadcast,
+    BroadcastConfig,
+    ConnectionConfig,
+    Message,
+    Msg,
+    Subscription,
+    should_endpoint_receive_item,
+)
+from lahja.exceptions import (
+    ConnectionAttemptRejected,
+    LifecycleError,
+    RemoteDisconnected,
+    UnexpectedResponse,
+)
+from lahja.typing import ConditionAPI, RequestID
+
+from .future import Future
+
+
+class TrioConnection(ConnectionAPI):
+    logger = logging.getLogger("lahja.trio.Connection")
+
+    def __init__(self, socket: trio.SocketStream) -> None:
+        self._socket = socket
+        self._msg_send_channel, self._msg_receive_channel = cast(
+            Tuple[trio.abc.SendChannel[Message], trio.abc.ReceiveChannel[Message]],
+            trio.open_memory_channel(100),
+        )
+        self._write_lock = trio.Lock()
+        super().__init__()
+
+    def __str__(self) -> str:
+        return f"TrioConnection[{self._socket}]"
+
+    def __repr__(self) -> str:
+        return f"<{self}>"
+
+    async def aclose(self) -> None:
+        await self._socket.aclose()
+
+    #
+    # Connection API
+    #
+    @classmethod
+    async def connect_to(cls, path: pathlib.Path) -> "TrioConnection":
+        socket = await trio.open_unix_socket(str(path))
+        cls.logger.debug("Opened connection to %s: %s", path, socket)
+        return cls(socket)
+
+    async def send_message(self, message: Msg) -> None:
+        msg_data = pickle.dumps(message)
+        size = len(msg_data)
+        try:
+            async with self._write_lock:
+                await self._socket.send_all(size.to_bytes(4, "little") + msg_data)
+        except (trio.ClosedResourceError, trio.BrokenResourceError) as err:
+            raise RemoteDisconnected from err
+
+    async def read_message(self) -> Message:
+        buffer = bytearray()
+
+        while len(buffer) < 4:
+            try:
+                data = await self._socket.receive_some(4 - len(buffer))
+            except (trio.ClosedResourceError, trio.BrokenResourceError) as err:
+                raise RemoteDisconnected from err
+
+            if data == b"":
+                raise RemoteDisconnected()
+
+            buffer.extend(data)
+
+        t_size = 4 + int.from_bytes(buffer[:4], "little")
+
+        while len(buffer) < t_size:
+            try:
+                data = await self._socket.receive_some(t_size - len(buffer))
+            except (trio.ClosedResourceError, trio.BrokenResourceError) as err:
+                raise RemoteDisconnected from err
+
+            if data == b"":
+                raise RemoteDisconnected()
+
+            buffer.extend(data)
+
+        msg = cast(Message, pickle.loads(buffer[4:t_size]))
+        return msg
+
+
+class TrioRemoteEndpoint(BaseRemoteEndpoint):
+    def __init__(
+        self,
+        local_name: str,
+        conn: ConnectionAPI,
+        subscriptions_changed: ConditionAPI,
+        new_msg_func: Callable[[Broadcast], Awaitable[Any]],
+    ) -> None:
+        super().__init__(local_name, conn, new_msg_func)
+
+        self._notify_lock = trio.Lock()  # type: ignore
+
+        self._received_response = trio.Condition()  # type: ignore
+        self._received_subscription = trio.Condition()  # type: ignore
+
+        self._running = trio.Event()  # type: ignore
+        self._stopped = trio.Event()  # type: ignore
+
+        self._received_subscription = subscriptions_changed
+
+        self._subscriptions_initialized = trio.Event()  # type: ignore
+
+        self._running = trio.Event()  # type: ignore
+        self._stopped = trio.Event()  # type: ignore
+        self._ready = trio.Event()  # type: ignore
+
+    @asynccontextmanager
+    async def run(self) -> AsyncIterator[RemoteEndpointAPI]:
+        async with trio.open_nursery() as nursery:
+            await self._start(nursery)
+            try:
+                yield self
+            finally:
+                await self.stop()
+
+    async def _start(self, nursery: trio_typing.Nursery) -> None:
+        if self.is_running:
+            raise LifecycleError("RemoteEndpoint is already running")
+        elif self.is_stopped:
+            raise LifecycleError("RemoteEndpoint has already been run and stopped")
+
+        nursery.start_soon(self._process_incoming_messages)
+        # this is a trade-off between allowing flexibility in how long it takes
+        # for a `Runnable` to start and getting good errors in the event that
+        # the `_run` method forgets to set the `_running` event.
+        with trio.fail_after(2):
+            await self.wait_started()
+
+    async def stop(self) -> None:
+        if self.is_stopped:
+            return
+        self._stopped.set()
+
+
+async def _wait_for_path(path: trio.Path) -> None:
+    """
+    Wait for the path to appear at ``path``
+    """
+    while not await path.exists():
+        await trio.sleep(0.05)
+
+
+WireBroadcastChannelPair = Tuple[
+    trio.abc.SendChannel[Broadcast], trio.abc.ReceiveChannel[Broadcast]
+]
+
+OutboundBroadcast = Tuple[
+    Optional[Future[None]], BaseEvent, Optional[BroadcastConfig], Optional[RequestID]
+]
+OutboundBroadcastChannelPair = Tuple[
+    trio.abc.SendChannel[OutboundBroadcast], trio.abc.ReceiveChannel[OutboundBroadcast]
+]
+
+ConnectionChannelPair = Tuple[
+    trio.abc.SendChannel[ConnectionConfig], trio.abc.ReceiveChannel[ConnectionConfig]
+]
+StreamChannelPair = Tuple[
+    trio.abc.SendChannel[BaseEvent], trio.abc.ReceiveChannel[BaseEvent]
+]
+
+
+class TrioEndpoint(BaseEndpoint):
+    _stream_channels: DefaultDict[Type[BaseEvent], Set[trio.abc.SendChannel[BaseEvent]]]
+    _pending_requests: Dict[RequestID, Future[BaseEvent]]
+
+    _sync_handlers: DefaultDict[Type[BaseEvent], List[Callable[[TSubscribeEvent], Any]]]
+    _async_handlers: DefaultDict[
+        Type[BaseEvent], List[Callable[[TSubscribeEvent], Awaitable[Any]]]
+    ]
+
+    logger = logging.getLogger("lahja.trio.TrioEndpoint")
+
+    _ipc_path: trio.Path
+
+    _subscriptions_changed: trio.Event
+
+    def __init__(self, name: str):
+        super().__init__(name)
+
+        self._running = trio.Event()
+        self._stopped = trio.Event()
+
+        # Temporary storage for SendChannels used in the `stream` API.  Uses a
+        # `WeakSet` to automate cleanup.
+        self._stream_channels = collections.defaultdict(set)
+        self._pending_requests = {}
+        self._sync_handlers = collections.defaultdict(list)
+        self._async_handlers = collections.defaultdict(list)
+
+        self._run_lock = trio.Lock()
+
+        # Signal when a new remote connection is established
+        self._remote_connections_changed = trio.Condition()  # type: ignore
+
+        # Signal when at least one remote has had a subscription change.
+        self._remote_subscriptions_changed = trio.Condition()  # type: ignore
+
+        # events used to signal that the endpoint has fully booted up.
+        self._message_processing_loop_running = trio.Event()
+        self._connection_loop_running = trio.Event()
+        self._process_broadcasts_running = trio.Event()
+
+        # internal signal that local subscriptions have changed.
+        self._subscriptions_changed = trio.Event()
+
+        self._server_running = trio.Event()
+        self._server_stopped = trio.Event()
+
+    #
+    # Running and endpoint
+    #
+    @property
+    def is_running(self) -> bool:
+        return not self.is_stopped and self._running.is_set()
+
+    @property
+    def is_stopped(self) -> bool:
+        return self._stopped.is_set()
+
+    async def wait_started(self) -> None:
+        await self._running.wait()
+
+    async def wait_stopped(self) -> None:
+        await self._stopped.wait()
+
+    @asynccontextmanager
+    async def run(self) -> AsyncGenerator[EndpointAPI, None]:
+        async with trio.open_nursery() as nursery:
+            await self._start(nursery)
+            try:
+                yield self
+            finally:
+                await self._stop()
+
+    async def _start(self, nursery: trio_typing.Nursery) -> None:
+        if self.is_running:
+            raise LifecycleError("Endpoint is already running")
+        elif self.is_stopped:
+            raise LifecycleError("Endpoint has already been run and stopped")
+
+        with trio.fail_after(2):
+            await nursery.start(self._run)
+
+            # this is a trade-off between allowing flexibility in how long it takes
+            # for a `Runnable` to start and getting good errors in the event that
+            # the `_run` method forgets to set the `_running` event.
+            await self.wait_started()
+
+    async def _stop(self) -> None:
+        if self.is_stopped:
+            return
+        self._stopped.set()
+        await self._cleanup()
+
+    async def _run(self, task_status: trio_typing.TaskStatus[None]) -> None:
+        # This send/receive channel is fed any event/config pair that should be
+        # broadcast.
+        # Those messages are then retrieved from the receive channel by the
+        # `_process_outbound_messages` daemon and broadcast to the appropriate
+        # `RemoteEndpoint`.
+        (self._outbound_send_channel, outbound_receive_channel) = cast(
+            OutboundBroadcastChannelPair, trio.open_memory_channel(100)
+        )
+
+        # This send/receive channel is fed by connected `RemoteEndpoint`
+        # objects which feed received events into the send side of the channel.
+        # Those messages are then retrieved from the receive channel by the
+        # `_process_inbound_messages` daemon.
+        (self._inbound_send_channel, inbound_receive_channel) = cast(
+            WireBroadcastChannelPair, trio.open_memory_channel(100)
+        )
+
+        # This send/receive channel is fed by
+        # `Endpoint.connect_to_endpoint` which places a 2-tuple of
+        # (ConnectionConfig, trio.Event) which is retrieved by
+        # `_process_connections`.
+        (self._connection_send_channel, connection_receive_channel) = cast(
+            ConnectionChannelPair, trio.open_memory_channel(100)
+        )
+
+        self.logger.debug("%s: starting", self)
+
+        async with trio.open_nursery() as nursery:
+            #
+            # _process_outbound_messages:
+            #     Manages a channel which all outgoing
+            #     event broadcasts are placed on, running them each through the
+            #     appropriate `RemoteEndpoint.send_message`
+            #
+            nursery.start_soon(
+                self._process_outbound_messages, outbound_receive_channel
+            )
+
+            #
+            # _process_inbound_messages:
+            #     Manages a channel which all incoming
+            #     event broadcasts are placed on, running each event through
+            #     the internal `_process_item` handler which handles all of the
+            #     internal logic for the various
+            #     `request/response/subscribe/stream/wait_for` API.
+            #
+            nursery.start_soon(self._process_inbound_messages, inbound_receive_channel)
+
+            #
+            # _process_connections:
+            #     When `Endpoint.connect_to_endpoint` is called, the actual
+            #     connection process is done asynchronously by putting the
+            #     `ConnectionConfig` onto a queue which this process
+            #     retrieves to establish the new connection.  This includes
+            #     handing the `RemoteEndpoint` oblect off to the `RemoteManager`
+            #     which takes care of the connection lifecycle.
+            #
+            nursery.start_soon(
+                self._process_connections, connection_receive_channel, nursery
+            )
+
+            #
+            # _monitor_subscription_changes
+            #    Monitors an event for local changes to subscriptions to
+            #    propagate those changes to remotes.
+            nursery.start_soon(self._monitor_subscription_changes)
+
+            # mark the endpoint as running.
+            self._running.set()
+            # tell the nursery that we are started.
+            task_status.started()
+
+            await self.wait_stopped()
+
+            nursery.cancel_scope.cancel()
+
+    async def _cleanup(self) -> None:
+        # Cleanup stateful things.
+        await self._outbound_send_channel.aclose()
+        await self._inbound_send_channel.aclose()
+        await self._connection_send_channel.aclose()
+
+        del self._outbound_send_channel
+        del self._inbound_send_channel
+        del self._connection_send_channel
+
+        self.logger.debug("%s: stopped", self)
+
+    #
+    # Background processes
+    #
+    async def _process_outbound_messages(
+        self, channel: trio.abc.ReceiveChannel[OutboundBroadcast]
+    ) -> None:
+        """
+        Consume events that have been received from a remote endpoint and
+        process them.
+        """
+        async for (fut, item, config, id) in channel:
+            item.bind(self, id)
+
+            is_eligible = should_endpoint_receive_item(
+                item, config, self.name, self.get_subscribed_events()
+            )
+            is_internal = config is not None and config.internal
+
+            if is_eligible:
+                await self._process_item(item, config)
+
+            if is_internal:
+                # if the event is flagged as internal we exit early since it should
+                # not be broadcast beyond this endpoint
+                return
+
+            remotes_for_broadcast = tuple(
+                remote
+                for remote in self._connections
+                if should_endpoint_receive_item(
+                    item, config, remote.name, remote.get_subscribed_events()
+                )
+            )
+
+            compressed_item = self._compress_event(item)
+            message = Broadcast(compressed_item, config)
+            for remote in remotes_for_broadcast:
+                try:
+                    await remote.send_message(message)
+                except RemoteDisconnected as err:
+                    self.logger.debug(
+                        "%s: dropping disconnected remote %s: %s", remote, err
+                    )
+                    await remote.stop()
+
+            # This Future is used to signal back to the `broadcast` method that
+            # this event has been broadcast and it is safe to return from the
+            # method.
+            if fut is not None:
+                fut.set_result(None)
+
+    async def _process_inbound_messages(
+        self, channel: trio.abc.ReceiveChannel[Broadcast]
+    ) -> None:
+        """
+        Consume events that have been received from a remote endpoint and
+        process them.
+        """
+        async for (item, config) in channel:
+            event = self._decompress_event(item)
+            await self._process_item(event, config)
+
+    async def _process_connections(
+        self,
+        channel: trio.abc.ReceiveChannel[ConnectionConfig],
+        nursery: trio_typing.Nursery,
+    ) -> None:
+        """
+        Long running process that establishes connections to endpoint servers
+        and runs the handler for receiving events sent by the server over that
+        connection.
+        """
+        self.logger.debug("%s: starting new connection channel", self)
+        self._connection_loop_running.set()
+        async for config in channel:
+            # Allow some time for for the IPC socket to appear
+            with trio.fail_after(constants.IPC_WAIT_SECONDS):
+                await _wait_for_path(trio.Path(config.path))
+
+            await trio.sleep(0.001)
+            # Establish the socket connection
+            connection = await TrioConnection.connect_to(config.path)
+
+            # Create the remote
+            remote = TrioRemoteEndpoint(
+                self.name,
+                connection,
+                self._remote_subscriptions_changed,
+                self._inbound_send_channel.send,
+            )
+            nursery.start_soon(self._run_remote_endpoint, remote)
+
+    async def _monitor_subscription_changes(self) -> None:
+        while not self.is_stopped:
+            # We wait for the event to change and then immediately replace it
+            # with a new event.  This **must** occur before any additional
+            # `await` calls to ensure that any *new* changes to the
+            # subscriptions end up operating on the *new* event and will be
+            # picked up in the next iteration of the loop.
+            await self._subscriptions_changed.wait()
+            self._subscriptions_changed = trio.Event()
+
+            # make a copy so that the set doesn't change while we iterate
+            # over it
+            subscribed_events = self.get_subscribed_events()
+
+            async with trio.open_nursery() as nursery:
+                async with self._remote_connections_changed:
+                    for remote in self._connections:
+                        nursery.start_soon(
+                            remote.notify_subscriptions_updated,
+                            subscribed_events,
+                            False,
+                        )
+            async with self._remote_subscriptions_changed:
+                self._remote_subscriptions_changed.notify_all()
+
+    async def _process_item(
+        self, item: BaseEvent, config: Optional[BroadcastConfig]
+    ) -> None:
+        event_type = type(item)
+
+        # handle request/response
+        if config is not None and config.filter_event_id in self._pending_requests:
+            fut = self._pending_requests.pop(config.filter_event_id)
+            fut.set_result(item)
+
+        # handle stream channel
+        if event_type in self._stream_channels:
+            channels = tuple(self._stream_channels[event_type])
+            for send_channel in channels:
+                try:
+                    await send_channel.send(item)
+                except trio.ClosedResourceError:
+                    self._stream_channels[event_type].remove(send_channel)
+
+        # handle subscriptions
+        if event_type in self._sync_handlers:
+            for handler_fn in self._sync_handlers[event_type]:
+                try:
+                    handler_fn(item)
+                except Exception as err:
+                    self.logger.debug(
+                        "%s: handler function %s error: %s", self, handler_fn, err
+                    )
+        if event_type in self._async_handlers:
+            for handler_fn in self._async_handlers[event_type]:
+                try:
+                    await handler_fn(item)
+                except Exception as err:
+                    self.logger.debug(
+                        "%s: handler function %s error: %s", self, handler_fn, err
+                    )
+
+    #
+    # Server API
+    #
+    @property
+    def is_serving(self) -> bool:
+        return not self.is_server_stopped and self._server_running.is_set()
+
+    @property
+    def is_server_stopped(self) -> bool:
+        return self._server_stopped.is_set()
+
+    @classmethod
+    @asynccontextmanager
+    async def serve(cls, config: ConnectionConfig) -> AsyncIterator["TrioEndpoint"]:
+        endpoint = cls(config.name)
+        async with endpoint.run():
+            async with trio.open_nursery() as nursery:
+                await endpoint._start_serving(nursery, trio.Path(config.path))
+                try:
+                    yield endpoint
+                finally:
+                    await endpoint._stop_serving()
+
+    async def _start_serving(
+        self, nursery: trio_typing.Nursery, ipc_path: trio.Path
+    ) -> None:
+        if not self.is_running:
+            raise LifecycleError("Cannot start server if endpoint is not running")
+        elif self.is_stopped:
+            raise LifecycleError("Endpoint has already been run and stopped")
+        elif self.is_serving:
+            raise LifecycleError("Endpoint is already serving")
+        elif self.is_server_stopped:
+            raise LifecycleError("Endpoint server already ran and was stopped")
+
+        self.ipc_path = ipc_path
+        nursery.start_soon(self._run_server, ipc_path)
+
+        # Wait until the ipc socket has appeared and is accepting connections.
+        with trio.fail_after(constants.IPC_WAIT_SECONDS):
+            await _wait_for_path(ipc_path)
+
+    async def _stop_serving(self) -> None:
+        if self.is_server_stopped:
+            return
+
+        self._server_stopped.set()
+        self._server_nursery.cancel_scope.cancel()
+
+        del self._server_nursery
+
+        try:
+            await self.ipc_path.unlink()
+        except OSError:
+            pass
+        self.logger.debug(f"%s: server stopped", self)
+
+    async def _run_server(self, ipc_path: trio.Path) -> None:
+        async with trio.open_nursery() as nursery:
+            # Store nursery on self so that we can access it for cancellation
+            self._server_nursery = nursery
+
+            self.logger.debug("%s: server starting", self)
+            socket = trio.socket.socket(trio.socket.AF_UNIX, trio.socket.SOCK_STREAM)
+            await socket.bind(self.ipc_path.__fspath__())
+            socket.listen(1)
+            listener = trio.SocketListener(socket)
+
+            self._server_running.set()
+
+            try:
+                await trio.serve_listeners(
+                    handler=self._accept_conn,
+                    listeners=(listener,),
+                    handler_nursery=nursery,
+                )
+            finally:
+                self.logger.debug("%s: server stopping", self)
+
+    async def _accept_conn(self, socket: trio.SocketStream) -> None:
+        self.logger.debug("%s: starting client handler for %s", self, socket)
+        connection = TrioConnection(socket)
+        remote = TrioRemoteEndpoint(
+            self.name,
+            connection,
+            self._remote_subscriptions_changed,
+            self._inbound_send_channel.send,
+        )
+        await self._run_remote_endpoint(remote)
+
+    #
+    # Establishing connections
+    #
+    async def connect_to_endpoints(self, *endpoints: ConnectionConfig) -> None:
+        """
+        Connect to the given endpoints and await until all connections are established.
+        """
+        if not self.is_running:
+            raise ConnectionAttemptRejected(
+                "Cannot establish connections if endpoint isn't running"
+            )
+
+        for config in endpoints:
+            # Ensure we are not already connected to the named endpoint
+            if self.is_connected_to(config.name):
+                raise ConnectionAttemptRejected(
+                    f"Already connected to endpoint with name: {config.name}"
+                )
+
+            # Feed the `ConnectionConfig` through a channel where
+            # `_process_connections` will pick it up and actually establish the
+            # connection.
+            await self._connection_send_channel.send(config)
+
+        for config in endpoints:
+            with trio.fail_after(constants.ENDPOINT_CONNECT_TIMEOUT):
+                await self.wait_until_connected_to(config.name)
+
+    #
+    # Primary endpoint API
+    #
+    async def broadcast(
+        self, item: BaseEvent, config: Optional[BroadcastConfig] = None
+    ) -> None:
+        """
+        Broadcast an instance of :class:`~lahja.common.BaseEvent` on the event bus. Takes
+        an optional second parameter of :class:`~lahja.common.BroadcastConfig` to decide
+        where this event should be broadcasted to. By default, events are broadcasted across
+        all connected endpoints with their consuming call sites.
+        """
+        fut: Future[None] = Future()
+        await self._outbound_send_channel.send((fut, item, config, None))
+        await fut
+
+    def broadcast_nowait(
+        self, item: BaseEvent, config: Optional[BroadcastConfig] = None
+    ) -> None:
+        self._outbound_send_channel.send_nowait((None, item, config, None))
+
+    TResponse = TypeVar("TResponse", bound=BaseEvent)
+
+    async def request(
+        self,
+        item: BaseRequestResponseEvent[TResponse],
+        config: Optional[BroadcastConfig] = None,
+    ) -> TResponse:
+        """
+        Broadcast an instance of
+        :class:`~lahja.common.BaseRequestResponseEvent` on the event bus and
+        immediately wait on an expected answer of type
+        :class:`~lahja.common.BaseEvent`. Optionally pass a second parameter of
+        :class:`~lahja.common.BroadcastConfig` to decide where the request
+        should be broadcasted to. By default, requests are broadcasted across
+        all connected endpoints with their consuming call sites.
+        """
+        request_id = next(self._get_request_id)
+
+        # Create an asynchronous generator that we use to pipe the result
+        fut: Future[TResponse] = Future()  # type: ignore
+
+        # place the send channel where the message processing loop can find it.
+        self._pending_requests[request_id] = fut
+
+        await self._outbound_send_channel.send((None, item, config, request_id))
+
+        # await for the result to be sent through the channel.
+        result: TResponse = await fut  # type: ignore
+        expected_response_type = item.expected_response_type()
+        if not isinstance(result, expected_response_type):
+            raise UnexpectedResponse(
+                f"The type of the response is {type(result)}, expected: "
+                f"{expected_response_type}"
+            )
+
+        return result
+
+    TSubscribeEvent = TypeVar("TSubscribeEvent", bound=BaseEvent)
+
+    def subscribe(
+        self,
+        event_type: Type[TSubscribeEvent],
+        handler: Callable[[TSubscribeEvent], Union[Any, Awaitable[Any]]],
+    ) -> Subscription:
+        """
+        Subscribe to receive updates for any event that matches the specified event type.
+        A handler is passed as a second argument an :class:`~lahja.common.Subscription` is returned
+        to unsubscribe from the event if needed.
+        """
+        if asyncio.iscoroutinefunction(handler):
+            self._async_handlers[event_type].append(handler)
+            subscription = Subscription(
+                lambda: self._async_handlers[event_type].remove(handler)
+            )
+        else:
+            self._sync_handlers[event_type].append(handler)
+            subscription = Subscription(
+                lambda: self._sync_handlers[event_type].remove(handler)
+            )
+
+        # notify subscriptions have been updated.
+        self._subscriptions_changed.set()
+
+        return subscription
+
+    TStreamEvent = TypeVar("TStreamEvent", bound=BaseEvent)
+
+    async def stream(
+        self, event_type: Type[TStreamEvent], num_events: Optional[int] = None
+    ) -> AsyncGenerator[TStreamEvent, None]:
+        """
+        Stream all events that match the specified event type. This returns an
+        ``AsyncIterable[BaseEvent]`` which can be consumed through an ``async for`` loop.
+        An optional ``num_events`` parameter can be passed to stop streaming after a maximum amount
+        of events was received.
+        """
+        (send_channel, receive_channel) = cast(
+            StreamChannelPair, trio.open_memory_channel(100)
+        )
+
+        self._stream_channels[event_type].add(send_channel)
+
+        # notify subscriptions have been updated.
+        self._subscriptions_changed.set()
+
+        if num_events is None:
+            # iterate forever
+            counter = itertools.count()
+        else:
+            # fixed number of iterations
+            counter = iter(range(max(0, num_events - 1)))
+
+        async for event in receive_channel:
+            yield event  # type: ignore  # mypy doesn't recognize this having a correct type
+
+            try:
+                next(counter)
+            except StopIteration:
+                await send_channel.aclose()
+                break
+
+        # We only need to trigger a subscription change if there are no more
+        # streams for this event.
+        self._stream_channels[event_type].remove(send_channel)
+        if not self._stream_channels[event_type]:
+            self._stream_channels.pop(event_type)
+            self._subscriptions_changed.set()
+
+    #
+    # Subscriptions API
+    #
+    def get_subscribed_events(self) -> Set[Type[BaseEvent]]:
+        """
+        Return the set of events this Endpoint is currently listening for
+        """
+        return (
+            set(self._sync_handlers.keys())
+            .union(self._async_handlers.keys())
+            .union(self._stream_channels.keys())
+        )

--- a/lahja/trio/future.py
+++ b/lahja/trio/future.py
@@ -1,0 +1,76 @@
+from concurrent.futures import CancelledError
+from types import TracebackType
+from typing import Any, Generator, Generic, Tuple, TypeVar
+
+import trio
+
+
+class InvalidState(Exception):
+    pass
+
+
+TResult = TypeVar("TResult")
+
+
+class Future(Generic[TResult]):
+    _error: Tuple[BaseException, TracebackType]
+    _result: TResult
+
+    _cancelled: bool
+    _did_error: bool
+
+    _done: trio.Event
+
+    def __init__(self) -> None:
+        self._cancelled = False
+        self._did_error = False
+        self._done = trio.Event()
+
+    def cancelled(self) -> bool:
+        return self._cancelled
+
+    def done(self) -> bool:
+        return self._done.is_set()
+
+    def result(self) -> TResult:
+        if self.cancelled():
+            raise CancelledError
+        elif self.done():
+            if self._did_error:
+                exc_value, exc_tb = self._error
+                raise exc_value.with_traceback(exc_tb)
+            else:
+                return self._result
+        else:
+            raise InvalidState()
+
+    def set_result(self, result: TResult) -> None:
+        self._result = result
+        self._done.set()
+
+    def set_exception(self, exc_value: Exception, exc_tb: TracebackType) -> None:
+        self._error = exc_value, exc_tb
+        self._done.set()
+        self._did_error = True
+
+    def cancel(self) -> bool:
+        if self.done():
+            return False
+        self._done.set()
+        self._cancelled = True
+        return True
+
+    def exception(self) -> BaseException:
+        if self.cancelled():
+            raise CancelledError
+        elif self.done() and self._did_error:
+            return self._error[0]
+        else:
+            raise InvalidState()
+
+    async def _await(self) -> TResult:
+        await self._done.wait()
+        return self.result()
+
+    def __await__(self) -> Generator[Any, None, TResult]:
+        return self._await().__await__()

--- a/scripts/perf_benchmark.py
+++ b/scripts/perf_benchmark.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 
 from lahja import ConnectionConfig
-from lahja.tools.benchmark.backends import AsyncioBackend, BaseBackend
+from lahja.tools.benchmark.backends import AsyncioBackend, BaseBackend, TrioBackend
 from lahja.tools.benchmark.constants import (
     DRIVER_ENDPOINT,
     REPORTER_ENDPOINT,
@@ -138,6 +138,8 @@ if __name__ == "__main__":
     for backend_str in args.backend or ["asyncio"]:
         if backend_str == "asyncio":
             backend = AsyncioBackend()
+        elif backend_str == "trio":
+            backend = TrioBackend()
         else:
             raise Exception(f"Unrecognized backend: {args.backend}")
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ extras_require = {
     'test-asyncio': [
         "pytest-asyncio==0.9.0",
     ],
+    'test-trio': [
+        "pytest-trio==0.5.2",
+    ],
     'lint': [
         "black==19.3b",
         "flake8==3.7.7",
@@ -59,6 +62,8 @@ setup(
     include_package_data=True,
     install_requires=[
         "async-generator>=1.10,<2",
+        "trio>=0.11,<0.12",
+        "trio_typing>=0.2.0,<0.3.0",
     ],
     python_requires='>=3.6, <4',
     extras_require=extras_require,

--- a/tests/core/asyncio/test_compat_with_trio_endpoint.py
+++ b/tests/core/asyncio/test_compat_with_trio_endpoint.py
@@ -1,0 +1,42 @@
+import multiprocessing
+
+import pytest
+import trio
+
+from lahja import BaseEvent
+from lahja.asyncio.endpoint import ConnectionConfig
+from lahja.trio.endpoint import TrioEndpoint
+
+
+class EventTest(BaseEvent):
+    def __init__(self, value):
+        self.value = value
+
+
+async def _do_trio_client_endpoint(name, ipc_path):
+    config = ConnectionConfig(name, ipc_path)
+    async with TrioEndpoint(name + "-client").run() as client:
+        await client.connect_to_endpoints(config)
+
+        assert client.is_connected_to(name)
+        await client.wait_until_endpoint_subscribed_to(config.name, EventTest)
+        event = EventTest("test")
+
+        await client.broadcast(event)
+
+
+@pytest.mark.asyncio
+async def test_legacy_endpoint_serving_trio_endpoint(endpoint_server, server_config):
+    name = server_config.name
+    path = server_config.path
+
+    proc = multiprocessing.Process(
+        target=trio.run, args=(_do_trio_client_endpoint, name, path)
+    )
+    proc.start()
+
+    result = await endpoint_server.wait_for(EventTest)
+    assert isinstance(result, EventTest)
+    assert result.value == "test"
+
+    proc.join()

--- a/tests/core/trio/conftest.py
+++ b/tests/core/trio/conftest.py
@@ -1,0 +1,50 @@
+import uuid
+
+import pytest
+import pytest_trio
+import trio
+
+from lahja import ConnectionConfig
+from lahja.trio.endpoint import TrioEndpoint
+
+
+def generate_unique_name() -> str:
+    # We use unique names to avoid clashing of IPC pipes
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def endpoint_server_config(ipc_base_path):
+    config = ConnectionConfig.from_name(generate_unique_name(), base_path=ipc_base_path)
+    return config
+
+
+@pytest_trio.trio_fixture
+async def endpoint_server(endpoint_server_config):
+    async with TrioEndpoint.serve(endpoint_server_config) as endpoint:
+        yield endpoint
+
+
+@pytest_trio.trio_fixture
+async def endpoint_client(endpoint_server_config, endpoint_server):
+    async with TrioEndpoint("client-for-testing").run() as client:
+        await client.connect_to_endpoints(endpoint_server_config)
+        while not endpoint_server.is_connected_to("client-for-testing"):
+            await trio.sleep(0)
+        yield client
+
+
+@pytest_trio.trio_fixture
+async def endpoint(nursery):
+    async with TrioEndpoint("endpoint-for-testing").run() as client:
+        yield client
+
+
+@pytest.fixture(params=("server_client", "client_server"))
+def endpoint_pair(request, endpoint_client, endpoint_server):
+    if request.param == "server_client":
+        return (endpoint_server, endpoint_client)
+    elif request.param == "client_server":
+        return (endpoint_client, endpoint_server)
+    else:
+        raise Exception(f"unknown param: {request.param}")

--- a/tests/core/trio/test_future.py
+++ b/tests/core/trio/test_future.py
@@ -1,0 +1,54 @@
+from concurrent.futures import CancelledError
+import sys
+
+import pytest
+import trio
+
+from lahja.trio.future import Future
+
+
+@pytest.mark.trio
+async def test_trio_future_result():
+    fut = Future()
+
+    async def do_set():
+        fut.set_result("done")
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(do_set)
+        result = await fut
+        assert result == "done"
+
+
+class ForTest(Exception):
+    pass
+
+
+@pytest.mark.trio
+async def test_trio_future_exception():
+    fut = Future()
+
+    async def do_set():
+        try:
+            raise ForTest("testing")
+        except ForTest:
+            _, err, tb = sys.exc_info()
+        fut.set_exception(err, tb)
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(do_set)
+        with pytest.raises(ForTest, match="testing"):
+            await fut
+
+
+@pytest.mark.trio
+async def test_trio_future_cancelled():
+    fut = Future()
+
+    async def do_set():
+        fut.cancel()
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(do_set)
+        with pytest.raises(CancelledError):
+            await fut

--- a/tests/core/trio/test_internal_events.py
+++ b/tests/core/trio/test_internal_events.py
@@ -1,0 +1,2 @@
+def test_it():
+    pass

--- a/tests/core/trio/test_server_establishes_reverse_connection.py
+++ b/tests/core/trio/test_server_establishes_reverse_connection.py
@@ -1,0 +1,24 @@
+import pytest
+import trio
+
+from conftest import generate_unique_name
+from lahja import ConnectionConfig
+from lahja.trio.endpoint import TrioEndpoint
+
+
+@pytest.mark.trio
+async def test_trio_server_endpoint_establishes_reverse_connection_to_client(
+    ipc_base_path
+):
+    unique_name = generate_unique_name()
+    config = ConnectionConfig.from_name(
+        f"server-{unique_name}", base_path=ipc_base_path
+    )
+
+    async with TrioEndpoint.serve(config) as server:
+        async with TrioEndpoint(f"client-{unique_name}").run() as client:
+            await client.connect_to_endpoints(config)
+
+            assert client.is_connected_to(config.name)
+            with trio.fail_after(2):
+                await server.wait_until_connected_to(client.name)

--- a/tests/core/trio/test_trio_endpoint_broadcast.py
+++ b/tests/core/trio/test_trio_endpoint_broadcast.py
@@ -1,0 +1,38 @@
+import logging
+
+import pytest
+import trio
+
+from lahja import BaseEvent
+
+
+class EventTest(BaseEvent):
+    def __init__(self, value):
+        self.value = value
+
+
+@pytest.mark.trio
+async def test_trio_endpoint_broadcast(endpoint_pair):
+    logging.info("HERE")
+    alice, bob = endpoint_pair
+
+    done = trio.Event()
+    event = EventTest("test")
+
+    async with trio.open_nursery() as nursery:
+
+        async def _do_wait_for():
+            logging.info("WAITING FOR EVENT")
+            result = await alice.wait_for(EventTest)
+            logging.info("GOT IT")
+            assert isinstance(result, EventTest)
+            assert result.value == "test"
+            done.set()
+
+        nursery.start_soon(_do_wait_for)
+        await bob.wait_until_endpoint_subscribed_to(alice.name, EventTest)
+
+        logging.info("BROADCASTING")
+        await bob.broadcast(event)
+        logging.info("WAITING DONE")
+        await done.wait()

--- a/tests/core/trio/test_trio_endpoint_compat_with_asyncio.py
+++ b/tests/core/trio/test_trio_endpoint_compat_with_asyncio.py
@@ -1,0 +1,49 @@
+import asyncio
+import multiprocessing
+
+import pytest
+
+from lahja.asyncio import AsyncioEndpoint
+from lahja.common import BaseEvent, ConnectionConfig
+
+
+class EventTest(BaseEvent):
+    def __init__(self, value):
+        self.value = value
+
+
+def run_asyncio(coro, *args):
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(coro(*args))
+    loop.close()
+
+
+async def _do_asyncio_client_endpoint(name, ipc_path):
+    config = ConnectionConfig(name, ipc_path)
+    async with AsyncioEndpoint(name + "client").run() as client:
+        await client.connect_to_endpoints(config)
+        assert client.is_connected_to(name)
+
+        await client.wait_until_endpoint_subscribed_to(config.name, EventTest)
+
+        event = EventTest("test")
+        await client.broadcast(event)
+
+
+@pytest.mark.trio
+async def test_trio_endpoint_serving_asyncio_endpoint(
+    endpoint_server, endpoint_server_config
+):
+    name = endpoint_server_config.name
+    path = endpoint_server_config.path
+
+    proc = multiprocessing.Process(
+        target=run_asyncio, args=(_do_asyncio_client_endpoint, name, path)
+    )
+    proc.start()
+
+    result = await endpoint_server.wait_for(EventTest)
+    assert isinstance(result, EventTest)
+    assert result.value == "test"
+
+    proc.join()

--- a/tests/core/trio/test_trio_endpoint_connect.py
+++ b/tests/core/trio/test_trio_endpoint_connect.py
@@ -1,0 +1,30 @@
+import pytest
+
+from conftest import generate_unique_name
+from lahja import ConnectionAttemptRejected, ConnectionConfig
+from lahja.trio.endpoint import TrioEndpoint
+
+
+@pytest.mark.trio
+async def test_connecting_to_other_trio_endpoint(ipc_base_path):
+    config = ConnectionConfig.from_name(generate_unique_name(), base_path=ipc_base_path)
+
+    async with TrioEndpoint.serve(config):
+        async with TrioEndpoint("client").run() as client:
+            await client.connect_to_endpoints(config)
+
+            assert client.is_connected_to(config.name)
+
+
+@pytest.mark.trio
+async def test_trio_duplicate_endpoint_connection_is_error(ipc_base_path):
+    config = ConnectionConfig.from_name(generate_unique_name(), base_path=ipc_base_path)
+
+    async with TrioEndpoint.serve(config):
+        async with TrioEndpoint("client").run() as client:
+            await client.connect_to_endpoints(config)
+
+            assert client.is_connected_to(config.name)
+
+            with pytest.raises(ConnectionAttemptRejected):
+                await client.connect_to_endpoints(config)

--- a/tests/core/trio/test_trio_endpoint_request_response.py
+++ b/tests/core/trio/test_trio_endpoint_request_response.py
@@ -1,0 +1,40 @@
+import pytest
+import trio
+
+from lahja import BaseEvent, BaseRequestResponseEvent, BroadcastConfig
+
+
+class DoubleResponse(BaseEvent):
+    def __init__(self, result):
+        self.result = result
+
+
+class DoubleRequest(BaseRequestResponseEvent[DoubleResponse]):
+    def __init__(self, value):
+        self.value = value
+
+    @staticmethod
+    def expected_response_type():
+        return DoubleResponse
+
+
+async def _handle_double_request(server):
+    request = await server.wait_for(DoubleRequest)
+    response = DoubleResponse(request.value * 2)
+    await server.broadcast(response, request.broadcast_config())
+
+
+@pytest.mark.trio
+async def test_trio_endpoint_request_and_response(endpoint_pair):
+    alice, bob = endpoint_pair
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(_handle_double_request, alice)
+
+        config = BroadcastConfig(alice.name)
+
+        await bob.wait_until_endpoint_subscribed_to(alice.name, DoubleRequest)
+
+        response = await bob.request(DoubleRequest(7), config)
+        assert isinstance(response, DoubleResponse)
+        assert response.result == 14

--- a/tests/core/trio/test_trio_endpoint_running.py
+++ b/tests/core/trio/test_trio_endpoint_running.py
@@ -1,0 +1,20 @@
+import pytest
+
+from lahja.trio.endpoint import TrioEndpoint
+
+
+@pytest.mark.trio
+async def test_trio_endpoint_as_contextmanager():
+    endpoint = TrioEndpoint("test")
+    assert endpoint.is_running is False
+
+    async with endpoint.run():
+        assert endpoint.is_running is True
+    assert endpoint.is_running is False
+
+
+@pytest.mark.trio
+async def test_trio_endpoint_as_contextmanager_inline():
+    async with TrioEndpoint("test").run() as endpoint:
+        assert endpoint.is_running is True
+    assert endpoint.is_running is False

--- a/tests/core/trio/test_trio_endpoint_stream.py
+++ b/tests/core/trio/test_trio_endpoint_stream.py
@@ -1,0 +1,72 @@
+import pytest
+import trio
+
+from lahja import BaseEvent
+
+
+class EventTest(BaseEvent):
+    def __init__(self, value):
+        self.value = value
+
+
+@pytest.mark.trio
+async def test_trio_endpoint_stream_without_limit(endpoint_pair):
+    alice, bob = endpoint_pair
+
+    async with trio.open_nursery() as nursery:
+        done = trio.Event()
+
+        async def _do_stream():
+            results = []
+            async for event in alice.stream(EventTest):
+                results.append(event)
+                if len(results) == 4:
+                    break
+
+            assert len(results) == 4
+            assert all(isinstance(result, EventTest) for result in results)
+
+            values = [result.value for result in results]
+            assert values == [0, 1, 2, 3]
+            done.set()
+
+        nursery.start_soon(_do_stream)
+        await bob.wait_until_endpoint_subscribed_to(alice.name, EventTest)
+
+        await bob.broadcast(EventTest(0))
+        await bob.broadcast(EventTest(1))
+        await bob.broadcast(EventTest(2))
+        await bob.broadcast(EventTest(3))
+
+        await done.wait()
+
+
+@pytest.mark.trio
+async def test_trio_endpoint_stream_with_limit(endpoint_pair):
+    alice, bob = endpoint_pair
+
+    async with trio.open_nursery() as nursery:
+        done = trio.Event()
+
+        async def _do_stream():
+            results = []
+            async for event in alice.stream(EventTest, num_events=4):
+                results.append(event)
+                assert len(results) <= 4
+
+            assert len(results) == 4
+            assert all(isinstance(result, EventTest) for result in results)
+
+            values = [result.value for result in results]
+            assert values == [0, 1, 2, 3]
+            done.set()
+
+        nursery.start_soon(_do_stream)
+
+        await bob.wait_until_endpoint_subscribed_to(alice.name, EventTest)
+        await bob.broadcast(EventTest(0))
+        await bob.broadcast(EventTest(1))
+        await bob.broadcast(EventTest(2))
+        await bob.broadcast(EventTest(3))
+
+        await done.wait()

--- a/tests/core/trio/test_trio_endpoint_subscribe.py
+++ b/tests/core/trio/test_trio_endpoint_subscribe.py
@@ -1,0 +1,70 @@
+import pytest
+import trio
+
+from lahja import BaseEvent
+
+
+class EventTest(BaseEvent):
+    pass
+
+
+class EventUnexpected(BaseEvent):
+    pass
+
+
+class EventInherited(EventTest):
+    pass
+
+
+@pytest.mark.trio
+async def test_trio_endpoint_subscribe(endpoint_pair):
+    alice, bob = endpoint_pair
+
+    results = []
+
+    alice.subscribe(EventTest, results.append)
+
+    await bob.wait_until_endpoint_subscribed_to(alice.name, EventTest)
+
+    await bob.broadcast(EventTest())
+    await bob.broadcast(EventUnexpected())
+    await bob.broadcast(EventInherited())
+    await bob.broadcast(EventTest())
+
+    # enough cycles to allow the alice to process the event
+    await trio.sleep(0.05)
+
+    assert len(results) == 2
+    assert all(type(event) is EventTest for event in results)
+
+
+@pytest.mark.trio
+async def test_trio_endpoint_unsubscribe(endpoint_pair):
+    alice, bob = endpoint_pair
+
+    results = []
+
+    subscription = alice.subscribe(EventTest, results.append)
+
+    await bob.wait_until_endpoint_subscribed_to(alice.name, EventTest)
+
+    await bob.broadcast(EventTest())
+    await bob.broadcast(EventUnexpected())
+    await bob.broadcast(EventInherited())
+    await bob.broadcast(EventTest())
+
+    # enough cycles to allow the alice to process the event
+    await trio.sleep(0.05)
+
+    subscription.unsubscribe()
+
+    await bob.broadcast(EventTest())
+    await bob.broadcast(EventUnexpected())
+    await bob.broadcast(EventInherited())
+    await bob.broadcast(EventTest())
+
+    # enough cycles to allow the alice to process the event
+    await trio.sleep(0.05)
+
+    assert len(results) == 2
+    assert all(type(event) is EventTest for event in results)

--- a/tests/core/trio/test_trio_endpoint_wait_for.py
+++ b/tests/core/trio/test_trio_endpoint_wait_for.py
@@ -1,0 +1,34 @@
+import pytest
+import trio
+
+from lahja import BaseEvent
+
+
+class EventTest(BaseEvent):
+    def __init__(self, value):
+        self.value = value
+
+
+@pytest.mark.trio
+async def test_trio_endpoint_wait_for(endpoint_pair):
+    alice, bob = endpoint_pair
+
+    # NOTE: this test is the inverse of the broadcast test
+    event = EventTest("test")
+
+    done = trio.Event()
+
+    async def _do_wait_for():
+        result = await alice.wait_for(EventTest)
+
+        assert isinstance(result, EventTest)
+        assert result.value == "test"
+        done.set()
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(_do_wait_for)
+
+        await bob.wait_until_endpoint_subscribed_to(alice.name, EventTest)
+
+        await bob.broadcast(event)
+        await done.wait()

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
 envlist=
-    py{36,37}-core-{asyncio}
     py{36,37}-examples
-    py{36,37}-snappy-core-{asyncio}
+    py{36,37}-core-{asyncio,trio}
+    py{36,37}-snappy-core-{asyncio,trio}
     lint
     doctest
 
 [isort]
 force_sort_within_sections=True
-known_third_party=hypothesis,pytest,async_generator,cytoolz
+known_third_party=hypothesis,pytest,async_generator,cytoolz,trio_typing,pytest_trio
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0
@@ -26,6 +26,7 @@ usedevelop=True
 commands=
     asyncio: pytest {posargs:tests/core/asyncio}
     examples: pytest {posargs:tests/examples}
+    trio: pytest {posargs:tests/core/trio}
     doctest: make -C {toxinidir}/docs doctest
 basepython =
     doctest: python
@@ -35,6 +36,7 @@ extras=
     test
     asyncio: test-asyncio
     examples: test-asyncio
+    trio: test-trio
     doctest: doc
     py36-snappy: snappy
     py37-snappy: snappy
@@ -46,21 +48,21 @@ whitelist_externals=
 basepython=python
 commands=
     # 10 processes with different number of events propagated
-    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 10 --num-events 10000"
+    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 10 --num-events 10000 --backend asyncio --backend trio"
     # Throttling the events slightly increases overall time but drastically reduces the average propagation time
-    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 10 --num-events 10000 --throttle 0.001"
-    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 10 --num-events 100"
-    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 10 --num-events 10"
+    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 10 --num-events 10000 --throttle 0.001 --backend asyncio --backend trio"
+    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 10 --num-events 100 --backend asyncio --backend trio"
+    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 10 --num-events 10 --backend asyncio --backend trio"
     # 3 processes, same number of events propagated
-    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 10000"
-    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 10000 --throttle 0.001"
-    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 100"
-    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 10"
+    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 10000 --backend asyncio --backend trio"
+    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 10000 --throttle 0.001 --backend asyncio --backend trio"
+    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 100 --backend asyncio --backend trio"
+    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 10 --backend asyncio --backend trio"
 
     # With 1Mb payload, max 1000 events
-    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 1000 --throttle 0.001 --payload-bytes 1000000"
-    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 100 --payload-bytes 1000000"
-    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 10 --payload-bytes 1000000"
+    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 1000 --throttle 0.001 --payload-bytes 1000000 --backend asyncio --backend trio"
+    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 100 --payload-bytes 1000000 --backend asyncio --backend trio"
+    bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 10 --payload-bytes 1000000 --backend asyncio --backend trio"
 
     # request/response
     bash -c "python {toxinidir}/scripts/perf_benchmark.py --num-processes 3 --num-events 1000 --mode request"


### PR DESCRIPTION
replaces #56

built on #133 #135 #136

## What was wrong?

We need a trio based endpoint implementation.

## How was it fixed?

Wrote an implementation using the `trio` library.

#### Cute Animal Picture


![4zvN5a](https://user-images.githubusercontent.com/824194/59457382-85920300-8dd5-11e9-8cd7-0ead35f96313.jpg)
