### PR TITLE
Convert exceptions to warnings

### DIFF
--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -481,11 +481,11 @@ class AsyncioEndpoint(BaseEndpoint):
 
     async def _add_connection(self, remote: RemoteEndpointAPI) -> None:
         if remote in self._connections:
-            raise Exception("TODO: remote is already tracked")
+            self.logger.warning("Remote is already tracked")
+            return
         elif self.is_connected_to(remote.name):
-            raise Exception(
-                f"TODO: already connected to remote with name {remote.name}"
-            )
+            self.logger.warning(f"Already connected to remote with name {remote.name}")
+            return
 
         async with self._remote_connections_changed:
             # then add them to our set of connections and signal that both


### PR DESCRIPTION
## What was wrong?

@pipermerriam I think that you aren't going to like this change so take this as me opening a discussion about how to resolve the problem at hand.

Currently, we are raising Exceptions if we attempt to add a connection that we already have. But here's the problem: The exceptions are raised from within

https://github.com/ethereum/lahja/blob/d7d50003a36a218433bd501b52331187be17523f/lahja/asyncio/endpoint.py#L482-L488

which is running in a background task:

https://github.com/ethereum/lahja/blob/d7d50003a36a218433bd501b52331187be17523f/lahja/asyncio/endpoint.py#L333

But not only are these exceptions being thrown in a background task, I would also argue that they are hard to prevent for the user in certain scenarios.

If you have Endpoint A and B and both try to connect to each other, then under the new model as soon as one has connected to the other, the connection is already working in both directions and the second endpoint trying to connect will cause such exception.

But if the user code deliberately does not care which endpoint starts connecting to the other one first (e.g. maybe the one that needs the other one first), this error seems hard to prevent and I feel degrading this to a warning may be justified.

This is more of a quick brain dump then a proper issue because it's late here and I just wanted to kick *something* off before I crash.

## How was it fixed?

Summary of approach.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
