### PR TITLE
Use proper exception classes

### DIFF
--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -481,10 +481,10 @@ class AsyncioEndpoint(BaseEndpoint):
 
     async def _add_connection(self, remote: RemoteEndpointAPI) -> None:
         if remote in self._connections:
-            raise Exception("TODO: remote is already tracked")
+            raise ConnectionAttemptRejected("Remote is already tracked")
         elif self.is_connected_to(remote.name):
-            raise Exception(
-                f"TODO: already connected to remote with name {remote.name}"
+            raise ConnectionAttemptRejected(
+                f"Already connected to remote with name {remote.name}"
             )
 
         async with self._remote_connections_changed:


### PR DESCRIPTION
## What was wrong?

Two places used `Exception` where `ConnectionAttemptRejected` would probably be more appropriate. Also the Exception message had a `TODO` in it.

## How was it fixed?

- use `ConnectionAttemptRejected` type
- get rid of todo in exception message

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://4.bp.blogspot.com/-AbdJlshYgho/UInmCfTPFBI/AAAAAAAABIk/Q_3xFGnCsBI/s1600/Felted+Traveling+Mouse.jpg)
