### PR TITLE
Fix long description on pipy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,26 +6,22 @@
 
 **DISCLAIMER: This is alpha state software. Expect bugs.**
 
-*Lahja is a generic multi process event bus implementation written in Python 3.6+ to enable lightweight inter-process communication, based on non-blocking asyncio.*
+*Lahja is a generic event bus implementation written in Python 3.6+ that enables lightweight inter-process communication, based on non-blocking asynchronous IO*
 
 ## What is this for?
 
-Lahja is tailored around one primary use case: enabling multi process Python applications to communicate through events between processes in a non-blocking
-asyncio fashion.
+Lahja is tailored around one primary use case: enabling multi process Python applications to communicate via events between processes using non-blocking APIs
+based on asyncio or trio.
 
 Key facts:
 
-- non-blocking APIs based on asyncio
-- lightweight and simple (e.g no IPC pipes etc)
+- non-blocking APIs using asynchronous IO (asyncio / trio)
+- lightweight with zero dependencies
+- simple to use
 - easy multicasting of events (one event, many independent receivers)
-- easy event routing (e.g route event X only to process group Y)
+- easy event routing (e.g route event X only to certain receivers)
 - multiple consuming APIs to adapt to different use cases and styles
 
-
-## TODOs
-
-- Push boundaries (don't push this into process x)
-- Testing
 
 ## Developer Setup
 

--- a/setup.py
+++ b/setup.py
@@ -43,13 +43,16 @@ extras_require['dev'].extend(extras_require['test'])
 extras_require['dev'].extend(extras_require['lint'])
 extras_require['dev'].extend(extras_require['doc'])
 
+with open('./README.md') as readme:
+    long_description = readme.read()
 
 setup(
     name='lahja',
     # *IMPORTANT*: Don't manually change the version here. Use `make bump`, as described in readme
     version='0.14.0',
     description="Generic event bus for inter process asyncio communication",
-    long_description_markdown_filename='README.md',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     author='The Lahja developers',
     author_email='christoph.burgdorf@gmail.com',
     url='https://github.com/ethereum/lahja',
@@ -57,7 +60,6 @@ setup(
     install_requires=[
         "async-generator>=1.10,<2",
     ],
-    setup_requires=['setuptools-markdown'],
     python_requires='>=3.5, <4',
     extras_require=extras_require,
     py_modules=['lahja'],

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     name='lahja',
     # *IMPORTANT*: Don't manually change the version here. Use `make bump`, as described in readme
     version='0.14.0',
-    description="Generic event bus for inter process asyncio communication",
+    description="Generic event bus for asynchronous cross-process communication",
     long_description=long_description,
     long_description_content_type='text/markdown',
     author='The Lahja developers',
@@ -60,12 +60,12 @@ setup(
     install_requires=[
         "async-generator>=1.10,<2",
     ],
-    python_requires='>=3.5, <4',
+    python_requires='>=3.6, <4',
     extras_require=extras_require,
     py_modules=['lahja'],
     license="MIT",
     zip_safe=False,
-    keywords='ethereum',
+    keywords='eventbus asyncio trio',
     packages=find_packages(exclude=["tests", "tests.*"]),
     package_data={'lahja': ['py.typed']},
     classifiers=[


### PR DESCRIPTION
## What was wrong?

The description on pipy could not handle the markdown syntax

## How was it fixed?

1. Manually handling the description in the same way we do for Trinity

2. Minor tweaks in the readme itself

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://upload.wikimedia.org/wikipedia/commons/thumb/6/68/Lynx_lynx_poing.jpg/266px-Lynx_lynx_poing.jpg)
