### PR TITLE
Use context manager api for remote endpoint running

### DIFF
--- a/lahja/tools/benchmark/process.py
+++ b/lahja/tools/benchmark/process.py
@@ -8,7 +8,7 @@ import time
 from typing import Any, AsyncGenerator, List, NamedTuple, Optional, Tuple  # noqa: F401
 
 from lahja import BroadcastConfig, ConnectionConfig
-from lahja.base import BaseEndpoint
+from lahja.base import EndpointAPI
 from lahja.tools.benchmark.backends import BaseBackend
 from lahja.tools.benchmark.constants import (
     DRIVER_ENDPOINT,
@@ -84,13 +84,13 @@ class BaseDriverProcess(ABC):
 
     @staticmethod
     @abstractmethod
-    async def do_driver(event_bus: BaseEndpoint, config: DriverProcessConfig) -> None:
+    async def do_driver(event_bus: EndpointAPI, config: DriverProcessConfig) -> None:
         ...
 
 
 class BroadcastDriver(BaseDriverProcess):
     @staticmethod
-    async def do_driver(event_bus: BaseEndpoint, config: DriverProcessConfig) -> None:
+    async def do_driver(event_bus: EndpointAPI, config: DriverProcessConfig) -> None:
         for consumer in config.connected_endpoints:
             await event_bus.wait_until_endpoint_subscribed_to(
                 consumer.name, PerfMeasureEvent
@@ -108,7 +108,7 @@ class BroadcastDriver(BaseDriverProcess):
 class RequestDriver(BaseDriverProcess):
     @classmethod
     async def do_driver(
-        cls, event_bus: BaseEndpoint, config: DriverProcessConfig
+        cls, event_bus: EndpointAPI, config: DriverProcessConfig
     ) -> None:
         for consumer in config.connected_endpoints:
             await event_bus.wait_until_endpoint_subscribed_to(
@@ -173,7 +173,7 @@ class BaseConsumerProcess(ABC):
     @staticmethod
     @abstractmethod
     async def do_consumer(
-        event_bus: BaseEndpoint, config: ConsumerConfig
+        event_bus: EndpointAPI, config: ConsumerConfig
     ) -> LocalStatistic:
         ...
 
@@ -181,7 +181,7 @@ class BaseConsumerProcess(ABC):
 class BroadcastConsumer(BaseConsumerProcess):
     @staticmethod
     async def do_consumer(
-        event_bus: BaseEndpoint, config: ConsumerConfig
+        event_bus: EndpointAPI, config: ConsumerConfig
     ) -> LocalStatistic:
         stats = LocalStatistic()
         events = event_bus.stream(PerfMeasureEvent, num_events=config.num_events)
@@ -193,7 +193,7 @@ class BroadcastConsumer(BaseConsumerProcess):
 class RequestConsumer(BaseConsumerProcess):
     @staticmethod
     async def do_consumer(
-        event_bus: BaseEndpoint, config: ConsumerConfig
+        event_bus: EndpointAPI, config: ConsumerConfig
     ) -> LocalStatistic:
         stats = LocalStatistic()
         events = event_bus.stream(PerfMeasureRequest, num_events=config.num_events)


### PR DESCRIPTION
Builds on #130 

## What was wrong?

The mechanisms for starting a background process in `trio` vs `asyncio` are not compatible.  In `trio`, our `start` methods have to be passed a nursery object in order for them to be capable of starting things up and then returning.

The `BaseEndpointAPI` defined a `start` method which results in the base implementation not being compatible with what we need for the trio implementation to fit within the model.

## How was it fixed?

Converted it to use the same async context manager pattern as endpoints via `remote.run()`, delegating the actual startup and shutdown logic to the actual implementation.

#### Cute Animal Picture

![10-05-30 Bella (181) C650](https://user-images.githubusercontent.com/824194/59378811-726a2f00-8d12-11e9-855a-bfeb66e57baf.JPG)

