### PR TITLE
Move RequestID generation to base endpoint

### DIFF
--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -51,7 +51,6 @@ from lahja.common import (
     ConnectionConfig,
     Message,
     Msg,
-    RequestIDGenerator,
     Subscription,
     should_endpoint_receive_item,
 )
@@ -199,19 +198,11 @@ class AsyncioEndpoint(BaseEndpoint):
     _sync_handler: DefaultDict[Type[BaseEvent], List[SubscriptionSyncHandler]]
 
     _loop: Optional[asyncio.AbstractEventLoop] = None
-    _get_request_id: Iterator[RequestID]
 
     _subscriptions_changed: asyncio.Event
 
     def __init__(self, name: str) -> None:
         super().__init__(name)
-
-        try:
-            self._get_request_id = RequestIDGenerator(name.encode("ascii") + b":")
-        except UnicodeDecodeError:
-            raise Exception(
-                f"TODO: Invalid endpoint name: '{name}'. Must be ASCII encodable string"
-            )
 
         # Signal when a new remote connection is established
         self._remote_connections_changed = asyncio.Condition()  # type: ignore


### PR DESCRIPTION
## What was wrong?

The logic for generating request ids can be shared by multiple endpoint implementations.

## How was it fixed?

Moved it onto the base endpoint class

#### Cute Animal Picture

![1a728c45997533626d1ebb8d4dd76366--cute-baby-animals-cutest-animals](https://user-images.githubusercontent.com/824194/59453366-f680ed00-8dcc-11e9-92a7-14e081a84f5c.jpg)
