### PR TITLE
Drop un-needed ignore statements on the async context managers

### DIFF
--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -154,7 +154,7 @@ class AsyncioRemoteEndpoint(BaseRemoteEndpoint):
     #
     # Running API
     #
-    @asynccontextmanager  # type: ignore
+    @asynccontextmanager
     async def run(self) -> AsyncIterator[RemoteEndpointAPI]:
         await self._start()
 
@@ -293,7 +293,7 @@ class AsyncioEndpoint(BaseEndpoint):
     #
     # Running API
     #
-    @asynccontextmanager  # type: ignore
+    @asynccontextmanager
     async def run(self) -> AsyncIterator[EndpointAPI]:
         if not self._loop:
             self._loop = asyncio.get_event_loop()
@@ -430,7 +430,7 @@ class AsyncioEndpoint(BaseEndpoint):
     # Server API
     #
     @classmethod
-    @asynccontextmanager  # type: ignore
+    @asynccontextmanager
     async def serve(cls, config: ConnectionConfig) -> AsyncIterator["AsyncioEndpoint"]:
         endpoint = cls(config.name)
         async with endpoint.run():


### PR DESCRIPTION
## What was wrong?

These ignore statements "may" no longer be needed.

## How was it fixed?

Remeoved them.

#### Cute Animal Picture

![monifa-hippo-7](https://user-images.githubusercontent.com/824194/59453439-216b4100-8dcd-11e9-82b6-f907223e2c80.jpg)

