### PR TITLE
Removed connect_to_endpoint and connect_to_endpoints_nowait API

### DIFF
--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -517,14 +517,6 @@ class AsyncioEndpoint(BaseEndpoint):
             *(self._await_connect_to_endpoint(endpoint) for endpoint in endpoints)
         )
 
-    def connect_to_endpoints_nowait(self, *endpoints: ConnectionConfig) -> None:
-        """
-        Connect to the given endpoints as soon as they become available but do not block.
-        """
-        self._throw_if_already_connected(*endpoints)
-        for endpoint in endpoints:
-            asyncio.ensure_future(self._await_connect_to_endpoint(endpoint))
-
     async def _await_connect_to_endpoint(self, endpoint: ConnectionConfig) -> None:
         await wait_for_path(endpoint.path)
         await self.connect_to_endpoint(endpoint)

--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -518,13 +518,10 @@ class AsyncioEndpoint(BaseEndpoint):
         )
 
     async def _await_connect_to_endpoint(self, endpoint: ConnectionConfig) -> None:
+        self._throw_if_already_connected(endpoint)
         await wait_for_path(endpoint.path)
-        await self.connect_to_endpoint(endpoint)
 
-    async def connect_to_endpoint(self, config: ConnectionConfig) -> None:
-        self._throw_if_already_connected(config)
-
-        conn = await AsyncioConnection.connect_to(config.path)
+        conn = await AsyncioConnection.connect_to(endpoint.path)
         remote = AsyncioRemoteEndpoint(
             local_name=self.name,
             conn=conn,
@@ -541,7 +538,7 @@ class AsyncioEndpoint(BaseEndpoint):
         # block until we've received the other endpoint's subscriptions to
         # ensure that it is safe to broadcast
         await asyncio.wait_for(
-            self.wait_until_connected_to(config.name),
+            self.wait_until_connected_to(endpoint.name),
             timeout=constants.ENDPOINT_CONNECT_TIMEOUT,
         )
 

--- a/lahja/base.py
+++ b/lahja/base.py
@@ -376,17 +376,11 @@ class EndpointAPI(ABC):
     #
     # Connection API
     #
-    @abstractmethod
-    async def connect_to_endpoint(self, config: ConnectionConfig) -> None:
-        """
-        Establish a new connection to an endpoint.
-        """
-        ...
 
     @abstractmethod
     async def connect_to_endpoints(self, *endpoints: ConnectionConfig) -> None:
         """
-        Variadic argument version of `connect_to_endpoint`
+        Establish connections to the given endpoints.
         """
         ...
 
@@ -611,14 +605,6 @@ class BaseEndpoint(EndpointAPI):
     #
     # Connection API
     #
-    async def connect_to_endpoints(self, *endpoints: ConnectionConfig) -> None:
-        """
-        Naive asynchronous implementation.  Subclasses should consider
-        connecting concurrently.
-        """
-        for config in endpoints:
-            await self.connect_to_endpoint(config)
-
     def is_connected_to(self, endpoint_name: str) -> bool:
         if endpoint_name == self.name:
             return True

--- a/tests/core/asyncio/conftest.py
+++ b/tests/core/asyncio/conftest.py
@@ -35,7 +35,7 @@ async def endpoint_server(server_config):
 @pytest.fixture
 async def endpoint_client(server_config, endpoint_server, unique_name):
     async with AsyncioEndpoint(f"client-{unique_name}").run() as client:
-        await client.connect_to_endpoint(server_config)
+        await client.connect_to_endpoints(server_config)
         await endpoint_server.wait_until_connected_to(client.name)
         yield client
 
@@ -55,6 +55,6 @@ async def server_with_two_clients(
     unique_name, server_config, endpoint_server, endpoint_client
 ):
     async with AsyncioEndpoint(f"3rd-wheel-{unique_name}").run() as client_b:
-        await client_b.connect_to_endpoint(server_config)
+        await client_b.connect_to_endpoints(server_config)
         await endpoint_server.wait_until_connected_to(client_b.name)
         yield endpoint_server, endpoint_client, client_b

--- a/tests/core/asyncio/test_asyncio_subscriptions_api.py
+++ b/tests/core/asyncio/test_asyncio_subscriptions_api.py
@@ -176,9 +176,9 @@ async def client_with_three_connections(ipc_base_path):
         async with AsyncioEndpoint.serve(config_b) as server_b:
             async with AsyncioEndpoint.serve(config_c) as server_c:
                 async with AsyncioEndpoint("client").run() as client:
-                    await client.connect_to_endpoint(config_a)
-                    await client.connect_to_endpoint(config_b)
-                    await client.connect_to_endpoint(config_c)
+                    await client.connect_to_endpoints(config_a)
+                    await client.connect_to_endpoints(config_b)
+                    await client.connect_to_endpoints(config_c)
 
                     yield client, server_a, server_b, server_c
 

--- a/tests/core/asyncio/test_base_wait_connections_changed_api.py
+++ b/tests/core/asyncio/test_base_wait_connections_changed_api.py
@@ -11,7 +11,7 @@ async def test_base_wait_until_connections_changed():
     config = ConnectionConfig.from_name(generate_unique_name())
     async with AsyncioEndpoint.serve(config):
         async with AsyncioEndpoint("client").run() as client:
-            asyncio.ensure_future(client.connect_to_endpoint(config))
+            asyncio.ensure_future(client.connect_to_endpoints(config))
 
             assert not client.is_connected_to(config.name)
             await asyncio.wait_for(client.wait_until_connections_change(), timeout=0.1)

--- a/tests/core/asyncio/test_base_wait_until_any_remote_subscriptions_changed_api.py
+++ b/tests/core/asyncio/test_base_wait_until_any_remote_subscriptions_changed_api.py
@@ -15,7 +15,7 @@ async def test_base_wait_until_any_endpoint_subscriptions_changed():
     config = ConnectionConfig.from_name(generate_unique_name())
     async with AsyncioEndpoint.serve(config) as server:
         async with AsyncioEndpoint("client").run() as client:
-            await client.connect_to_endpoint(config)
+            await client.connect_to_endpoints(config)
             assert client.is_connected_to(config.name)
 
             server.subscribe(SubscriptionEvent, lambda e: None)

--- a/tests/core/asyncio/test_connect.py
+++ b/tests/core/asyncio/test_connect.py
@@ -10,7 +10,7 @@ from lahja import AsyncioEndpoint, ConnectionAttemptRejected, ConnectionConfig
 async def test_connect_to_endpoint(endpoint):
     config = ConnectionConfig.from_name(generate_unique_name())
     async with AsyncioEndpoint.serve(config):
-        await endpoint.connect_to_endpoint(config)
+        await endpoint.connect_to_endpoints(config)
         assert endpoint.is_connected_to(config.name)
 
 
@@ -18,7 +18,7 @@ async def test_connect_to_endpoint(endpoint):
 async def test_wait_until_connected_to(endpoint):
     config = ConnectionConfig.from_name(generate_unique_name())
     async with AsyncioEndpoint.serve(config):
-        asyncio.ensure_future(endpoint.connect_to_endpoint(config))
+        asyncio.ensure_future(endpoint.connect_to_endpoints(config))
 
         assert not endpoint.is_connected_to(config.name)
         await endpoint.wait_until_connected_to(config.name)
@@ -29,7 +29,7 @@ async def test_wait_until_connected_to(endpoint):
 async def test_server_establishes_reverse_connection(endpoint):
     config = ConnectionConfig.from_name(generate_unique_name())
     async with AsyncioEndpoint.serve(config) as server:
-        await endpoint.connect_to_endpoint(config)
+        await endpoint.connect_to_endpoints(config)
         assert endpoint.is_connected_to(config.name)
         assert server.is_connected_to(endpoint.name)
 
@@ -38,14 +38,14 @@ async def test_server_establishes_reverse_connection(endpoint):
 async def test_rejects_duplicates_when_connecting(endpoint):
     config = ConnectionConfig.from_name(generate_unique_name())
     async with AsyncioEndpoint.serve(config):
-        await endpoint.connect_to_endpoint(config)
+        await endpoint.connect_to_endpoints(config)
 
         assert endpoint.is_connected_to(config.name)
         with pytest.raises(ConnectionAttemptRejected):
-            await endpoint.connect_to_endpoint(config)
+            await endpoint.connect_to_endpoints(config)
 
 
 @pytest.mark.asyncio
 async def test_endpoint_rejects_self_connection(endpoint_server, server_config):
     with pytest.raises(ConnectionAttemptRejected):
-        await endpoint_server.connect_to_endpoint(server_config)
+        await endpoint_server.connect_to_endpoints(server_config)


### PR DESCRIPTION
## What was wrong?

1. Usage of `connect_to_endpoints_nowait` was discouraged and Trinity does not need it anymore

2. Having variadic `connect_to_endpoints` and non-variadic `connect_to_endpoint` is unnecessary as the former is a superset of the latter.

## How was it fixed?

Removed both APIs.

Bonus: `_await_connect_to_endpoint` throws earlier in case of errors now

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.wallpaperup.com/uploads/wallpapers/2015/06/11/719430/66d1176982ac153d427b5d447b8453af-700.jpg)
