### PR TITLE
Add missing decorators

### DIFF
--- a/lahja/base.py
+++ b/lahja/base.py
@@ -85,14 +85,17 @@ class RemoteEndpointAPI(ABC):
     async def wait_stopped(self) -> None:
         ...
 
+    @property
     @abstractmethod
     def is_running(self) -> bool:
         ...
 
+    @property
     @abstractmethod
     def is_ready(self) -> bool:
         ...
 
+    @property
     @abstractmethod
     def is_stopped(self) -> bool:
         ...


### PR DESCRIPTION
## What was wrong?

@property decorators are missing in the base class

## How was it fixed?

Added them

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://live.staticflickr.com/2706/4251212603_1ba82b9c59_b.jpg)
