### PR TITLE
Fix wrong title in docs and license

### DIFF
--- a/.project-template/template_vars.txt
+++ b/.project-template/template_vars.txt
@@ -2,5 +2,5 @@ lahja
 lahja
 lahja
 lahja
-<PROJECT_NAME>
-<SHORT_DESCRIPTION>
+lahja
+Lahja is a generic multi process event bus

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 Jason Carver
+Copyright (c) 2017-2018 Ethereum Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# <PROJECT_NAME> documentation build configuration file, created by
+# lahja documentation build configuration file, created by
 # sphinx-quickstart on Thu Oct 16 20:43:24 2014.
 #
 # This file is execfile()d with the current directory set to its
@@ -53,8 +53,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = '<PROJECT_NAME>'
-copyright = '2018, Jason Carver, Piper Merriam'
+project = 'lahja'
+copyright = '2018-2019 Ethereum Foundation'
 
 __version__ = setup_version
 # The version info for the project you're documenting, acts as replacement for
@@ -209,8 +209,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'lahja.tex', '<PROJECT_NAME> Documentation',
-   'Jason Carver', 'manual'),
+  ('index', 'lahja.tex', 'lahja Documentation', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -239,8 +238,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'lahja', '<PROJECT_NAME> Documentation',
-     ['Jason Carver'], 1)
+    ('index', 'lahja', 'lahja Documentation', 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -253,8 +251,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', '<PROJECT_NAME>', '<PROJECT_NAME> Documentation',
-   'Jason Carver', '<PROJECT_NAME>', '<SHORT_DESCRIPTION>',
+  ('index', 'lahja', 'lahja Documentation', 'lahja',
+  'Lahja is a generic multi process event bus',
    'Miscellaneous'),
 ]
 

--- a/newsfragments/150.doc.rst
+++ b/newsfragments/150.doc.rst
@@ -1,0 +1,1 @@
+Fix wrong title in docs as well as wrong info in license.


### PR DESCRIPTION
### What was wrong?

1. Title in docs is wrong

![image](https://user-images.githubusercontent.com/521109/62525425-ad32a400-b837-11e9-8365-4a52d02081ec.png)

2. License info was wrong

### How was it fixed?

1. Refilled template vars

2. Manually adjusted some places to adjust copyright etc.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/lahja/blob/master/newsfragments/README.md)

[//]: # (See: https://lahja.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/lahja/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://themysteriousworld.com/wp-content/uploads/2013/12/Pheasant-Bird.jpg)