### PR TITLE
Improve visuals of API docs

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -18,3 +18,46 @@ tt, code, pre {
   margin: 0;
   padding: 0;
 }
+
+/* We instruct sphinx to order members groupwise and use the following css to add headlines.
+Notice that while the css differentiates between methods, classmethods and staticmethods,
+unfortunately, sphinx groups these all alphabetically as methods which means we only
+display them as one "methods" group. */
+
+dl.attribute:before {
+  content: "Attributes";
+}
+
+dl.method:before,
+dl.classmethod:before,
+dl.staticmethod:before {
+  content: "Methods";
+}
+
+dl.method:before,
+dl.attribute:before,
+dl.classmethod:before,
+dl.staticmethod:before {
+  background: #e7f2fa;
+  border-top: solid 3px #6ab0de;
+  color: #000;
+  display: inline-block;
+  font-weight: bold;
+  margin: 5px 0 10px 0;
+  padding: 5px;
+}
+
+/* Remove method header if a previous element already introduced it */
+dl.attribute + dl.attribute:before,
+/* We have to treat all these as just "methods" (see comment further above) */
+dl.method + dl.method:before,
+dl.classmethod + dl.method:before,
+dl.staticmethod + dl.method:before,
+dl.method + dl.classmethod:before,
+dl.classmethod + dl.classmethod:before,
+dl.staticmethod + dl.classmethod:before,
+dl.method + dl.staticmethod:before,
+dl.staticmethod + dl.staticmethod:before,
+dl.classmethod + dl.staticmethod:before {
+  display: none;
+}

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,20 @@
+tt, code, pre {
+  font-family: monospace, sans-serif;
+  font-size: 96.5%;
+}
+
+.rst-content dl:not(.docutils) tt.descname,
+.rst-content dl:not(.docutils) tt.descclassname,
+.rst-content dl:not(.docutils) tt.descname,
+.rst-content dl:not(.docutils) code.descname,
+.rst-content dl:not(.docutils) tt.descclassname,
+.rst-content dl:not(.docutils) code.descclassname {
+  font-size: 130% !important;
+}
+
+.rst-content dl:not(.docutils) dl dt {
+  background: #fff;
+  border: none;
+  margin: 0;
+  padding: 0;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -142,6 +142,9 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+def setup(app):
+    app.add_stylesheet("css/custom.css")
+
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,8 @@ extensions = [
     'sphinx.ext.intersphinx',
 ]
 
+autodoc_member_order = 'groupwise'
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/newsfragments/152.doc.rst
+++ b/newsfragments/152.doc.rst
@@ -1,1 +1,2 @@
 Remove visual clutter from API docs
+Group methods and attributes in API docs

--- a/newsfragments/152.doc.rst
+++ b/newsfragments/152.doc.rst
@@ -1,0 +1,1 @@
+Remove visual clutter from API docs


### PR DESCRIPTION
### What was wrong?

1. Lots of grey boxes make API docs harder to parse (visually)

2. Methods and attributes not being grouped makes it even harder and error prone for the reader ("Do I call this with or without parenthesis?")

Visuals today:

![image](https://user-images.githubusercontent.com/521109/62544666-88065b80-b860-11e9-81f0-e7b95eb1a4d2.png)


### How was it fixed?

1. Removed grey boxes
2. Improved fonts and spacing
3. Grouped methods and attributes

Visuals after this PR:

![improved_api_docs](https://user-images.githubusercontent.com/521109/62545826-b8e79000-b862-11e9-890c-b8844d77a1e8.png)


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/lahja/blob/master/newsfragments/README.md)

[//]: # (See: https://lahja.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/lahja/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.maxpixel.net/static/photo/1x/Black-Rotflanken-colorful-Squirrel-Squirrel-Orange-2332339.jpg)