### PR TITLE
Fix broken Latex generation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -214,7 +214,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'lahja.tex', 'lahja Documentation', 'manual'),
+  ('index', 'lahja.tex', 'lahja Documentation', 'Ethereum Foundation', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -243,7 +243,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'lahja', 'lahja Documentation', 1)
+    ('index', 'lahja', 'lahja Documentation', ['Ethereum Foundation'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -256,7 +256,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'lahja', 'lahja Documentation', 'lahja',
+  ('index', 'lahja', 'lahja Documentation', 'Ethereum Foundation', 'lahja',
   'Lahja is a generic multi process event bus',
    'Miscellaneous'),
 ]

--- a/newsfragments/155.doc.rst
+++ b/newsfragments/155.doc.rst
@@ -1,0 +1,1 @@
+Fix broken RTD build by re-adding some info that is important for the latex job.


### PR DESCRIPTION
### What was wrong?

Turns out readthedocs build is broken because the latex generation broke

### How was it fixed?

Re-add some missing info that latex needs.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/lahja/blob/master/newsfragments/README.md)

[//]: # (See: https://lahja.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/lahja/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.cutestpaw.com/wp-content/uploads/2014/06/Cutest-Pics-of-Baby-Wild-Animals.jpg)