### PR TITLE
Use the highest available pickle protocol

### DIFF
--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -89,7 +89,7 @@ class AsyncioConnection(ConnectionAPI):
         return cls(reader, writer)
 
     async def send_message(self, message: Msg) -> None:
-        pickled = pickle.dumps(message)
+        pickled = pickle.dumps(message, protocol=pickle.HIGHEST_PROTOCOL)
         size = len(pickled)
 
         try:

--- a/lahja/base.py
+++ b/lahja/base.py
@@ -776,7 +776,10 @@ class BaseEndpoint(EndpointAPI):
         if self.has_snappy_support:
             import snappy
 
-            return cast(bytes, snappy.compress(pickle.dumps(event)))
+            return cast(
+                bytes,
+                snappy.compress(pickle.dumps(event, protocol=pickle.HIGHEST_PROTOCOL)),
+            )
         else:
             return event
 

--- a/lahja/trio/endpoint.py
+++ b/lahja/trio/endpoint.py
@@ -90,7 +90,7 @@ class TrioConnection(ConnectionAPI):
         return cls(socket)
 
     async def send_message(self, message: Msg) -> None:
-        msg_data = pickle.dumps(message)
+        msg_data = pickle.dumps(message, protocol=pickle.HIGHEST_PROTOCOL)
         size = len(msg_data)
         try:
             async with self._write_lock:

--- a/newsfragments/156.feature.rst
+++ b/newsfragments/156.feature.rst
@@ -1,0 +1,1 @@
+Ensure ``stream()`` does not suppress ``CancelledError``

--- a/newsfragments/160.feature.rst
+++ b/newsfragments/160.feature.rst
@@ -1,0 +1,3 @@
+Use the highest available `pickle` protocol. This yields a notable performance
+improvement on Python < 3.8 which are still using version 3 of the protocol by
+default.

--- a/newsfragments/feature.156.rst
+++ b/newsfragments/feature.156.rst
@@ -1,1 +1,0 @@
-Ensure ``stream()`` does not suppress ``CancelledError``

--- a/tests/core/asyncio/test_basics.py
+++ b/tests/core/asyncio/test_basics.py
@@ -258,4 +258,4 @@ def test_pickle_fails():
     alice = AsyncioEndpoint("pickle-test")
 
     with pytest.raises(Exception):
-        pickle.dumps(alice)
+        pickle.dumps(alice, protocol=pickle.HIGHEST_PROTOCOL)


### PR DESCRIPTION
### What was wrong?

On Python < 3.8 (which isn't released yet) pickle still uses version `3` of the protocol by default (even though version `4` is already available. Python 3.8 will make version `5` the default protocol.

### How was it fixed?

Always use the highest available pickle protocol.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/lahja/blob/master/newsfragments/README.md)

[//]: # (See: https://lahja.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/lahja/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.davecumbervets.co.uk/wp-content/uploads/2019/02/pexels-photo-134061-1024x675.jpeg)