### PR TITLE
Update to trio 0.13

### DIFF
--- a/newsfragments/163.misc.rst
+++ b/newsfragments/163.misc.rst
@@ -1,0 +1,1 @@
+Update Trio dependency to ``trio>=0.13.0,<0.14``

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "async-generator>=1.10,<2",
-        "trio>=0.11,<0.12",
+        "trio>=0.13,<0.14",
         "trio_typing>=0.2.0,<0.3.0",
     ],
     python_requires='>=3.6, <4',


### PR DESCRIPTION
### What was wrong?

Newer versions of trio are available.  We want 0.13 since it fixes a bunch of deprecation warnings.

### How was it fixed?

Updated to `trio>=0.13,<0.14`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/lahja/blob/master/newsfragments/README.md)

[//]: # (See: https://lahja.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/lahja/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![harbor-seal-pup-DP](https://user-images.githubusercontent.com/824194/69108462-f1863080-0a31-11ea-9bad-230a00807899.jpg)
