### PR TITLE
A couple fixes to TrioEndpoint

### DIFF
--- a/newsfragments/170.bugfix.rst
+++ b/newsfragments/170.bugfix.rst
@@ -1,0 +1,6 @@
+A couple fixes to TrioEndpoint
+
+ - allow more than one pending incoming connection, and use a class
+   attribute to configure that instead of hard-coding
+ - wait for the socket to be bound in _start_serving() so that others
+   don't try to connect too soon


### PR DESCRIPTION
### What was wrong?

In trinity with the new (in progress, trio-based) peer discovery
protocol, sometimes other endpoints were trying to connect too soon,
before the IPC socket file was bound, causing an error

Also, multiple other endpoints will usually try to connect
simultaneously, causing an error as TrioEndpoint's IPC socket was
hard-coded to accept only one pending connection.

### How was it fixed?

- allow more than one pending incoming connection, and use a class
attribute to configure that instead of hard-coding

- wait for the socket to be bound in _start_serving() so that others
don't try to connect too soon.


### To-Do

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/lahja/blob/master/newsfragments/README.md)