### PR TITLE
Add Matomo tracking

### DIFF
--- a/docs/_static/js/matomo.js
+++ b/docs/_static/js/matomo.js
@@ -1,0 +1,11 @@
+var _paq = window._paq || [];
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function() {
+  var u="https://matomo.ethereum.org/piwik/";
+  _paq.push(['setTrackerUrl', u+'matomo.php']);
+  _paq.push(['setSiteId', '19']);
+  var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+  g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+})();

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,7 +145,8 @@ html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
 
 def setup(app):
-    app.add_stylesheet("css/custom.css")
+    app.add_css_file("css/custom.css")
+    app.add_js_file("js/matomo.js")
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/newsfragments/171.doc.rst
+++ b/newsfragments/171.doc.rst
@@ -1,0 +1,7 @@
+Add Matomo Tracking to Docs site.
+
+Matomo is an Open Source web analytics platform that allows us
+to get better insights and optimize for our audience without
+the negative consequences of other compareable platforms.
+
+Read more: https://matomo.org/why-matomo/


### PR DESCRIPTION
### What was wrong?

Currently we do not have a good insight into our target group. In order to improve both Trinity itself and the documentation, it makes sense to aggregate some data.

### How was it fixed?

Add Matomo Tracking to Docs site.

Matomo is an Open Source web analytics platform that allows us
to get better insights and optimize for our audience without
the negative consequences of other compareable platforms.

Read more: https://matomo.org/why-matomo/

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/lahja/blob/master/newsfragments/README.md)

[//]: # (See: https://lahja.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/lahja/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://sacramento.cbslocal.com/wp-content/uploads/sites/15909776/2013/04/baby-sea-turtles.jpg)
