### PR TITLE
Raise error if broadcast/request has no subscribers

### DIFF
--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -567,6 +567,7 @@ class AsyncioEndpoint(BaseEndpoint):
         where this event should be broadcasted to. By default, events are broadcasted across
         all connected endpoints with their consuming call sites.
         """
+        self.maybe_raise_no_subscribers_exception(config, type(item))
         await self._broadcast(item, config, None)
 
     async def _broadcast(
@@ -626,6 +627,7 @@ class AsyncioEndpoint(BaseEndpoint):
         accepting new messages this function will continue to accept them, which in the
         worst case could lead to runaway memory usage.
         """
+        self.maybe_raise_no_subscribers_exception(config, type(item))
         asyncio.ensure_future(self._broadcast(item, config, None))
 
     @check_event_loop
@@ -643,6 +645,7 @@ class AsyncioEndpoint(BaseEndpoint):
         should be broadcasted to. By default, requests are broadcasted across
         all connected endpoints with their consuming call sites.
         """
+        self.maybe_raise_no_subscribers_exception(config, type(item))
         request_id = next(self._get_request_id)
 
         future: "asyncio.Future[TResponse]" = asyncio.Future()

--- a/lahja/common.py
+++ b/lahja/common.py
@@ -36,11 +36,13 @@ class BroadcastConfig:
         filter_endpoint: Optional[str] = None,
         filter_event_id: Optional[RequestID] = None,
         internal: bool = False,
+        require_subscriber: bool = True,
     ) -> None:
 
         self.filter_endpoint = filter_endpoint
         self.filter_event_id = filter_event_id
         self.internal = internal
+        self.require_subscriber = require_subscriber
 
         if self.internal and self.filter_endpoint is not None:
             raise ValueError("`internal` can not be used with `filter_endpoint")

--- a/lahja/exceptions.py
+++ b/lahja/exceptions.py
@@ -12,6 +12,14 @@ class BindError(LahjaError):
     """
 
 
+class ConnectionAttemptRejected(LahjaError):
+    """
+    Raised when an attempt was made to connect to an endpoint that is already connected.
+    """
+
+    pass
+
+
 class LifecycleError(LahjaError):
     """
     Raised when attempting to violate the lifecycle of an endpoint such as
@@ -22,9 +30,12 @@ class LifecycleError(LahjaError):
     pass
 
 
-class ConnectionAttemptRejected(LahjaError):
+class NoSubscribers(LahjaError):
     """
-    Raised when an attempt was made to connect to an endpoint that is already connected.
+    Raised when attempting to send an event or make a request while there are no listeners for the
+    specific type of event or request.
+    This is a safety check, set ``require_subscriber`` of :class:`~lahja.base.BroadcastConfig`
+    to ``False`` to allow propagation without listeners.
     """
 
     pass

--- a/lahja/trio/endpoint.py
+++ b/lahja/trio/endpoint.py
@@ -688,6 +688,7 @@ class TrioEndpoint(BaseEndpoint):
         where this event should be broadcasted to. By default, events are broadcasted across
         all connected endpoints with their consuming call sites.
         """
+        self.maybe_raise_no_subscribers_exception(config, type(item))
         done = trio.Event()
         await self._outbound_send_channel.send((done, item, config, None))
         await done.wait()
@@ -695,6 +696,7 @@ class TrioEndpoint(BaseEndpoint):
     def broadcast_nowait(
         self, item: BaseEvent, config: Optional[BroadcastConfig] = None
     ) -> None:
+        self.maybe_raise_no_subscribers_exception(config, type(item))
         # FIXME: Ignoring type check because of https://github.com/python-trio/trio/issues/1327
         self._outbound_send_channel.send_nowait(  # type: ignore
             (None, item, config, None)
@@ -716,6 +718,7 @@ class TrioEndpoint(BaseEndpoint):
         should be broadcasted to. By default, requests are broadcasted across
         all connected endpoints with their consuming call sites.
         """
+        self.maybe_raise_no_subscribers_exception(config, type(item))
         request_id = next(self._get_request_id)
 
         # Create an asynchronous generator that we use to pipe the result

--- a/newsfragments/176.feature.rst
+++ b/newsfragments/176.feature.rst
@@ -1,0 +1,11 @@
+Raise :class:`~lahja.exceptions.NoSubscribers` exception if an event
+is broadcasted or a request is made while there are no subscribers to
+the specific event or request type. This is a safety check to avoid
+scenarios where events or requests are never answered because developers
+forgot to wire certain events or requests together.
+
+If however, certain events or requests aren't expected to be subscribed to,
+one can explicitly set ``require_subscriber`` on the
+:class:`~lahja.common.BroadcastConfig` to ``False``.
+
+This is a **BREAKING CHANGE**.

--- a/tests/core/asyncio/test_asyncio_subscriptions_api.py
+++ b/tests/core/asyncio/test_asyncio_subscriptions_api.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from lahja import AsyncioEndpoint, BaseEvent, ConnectionConfig
+from lahja import AsyncioEndpoint, BaseEvent, BroadcastConfig, ConnectionConfig
 
 
 class StreamEvent(BaseEvent):
@@ -110,8 +110,12 @@ async def test_asyncio_subscription_api_does_not_match_inherited_classes(endpoin
     assert StreamEvent in subscriber.get_subscribed_events()
 
     # Broadcast two of the inherited events and then the correct event.
-    await other.broadcast(InheretedStreamEvent())
-    await other.broadcast(InheretedStreamEvent())
+    await other.broadcast(
+        InheretedStreamEvent(), BroadcastConfig(require_subscriber=False)
+    )
+    await other.broadcast(
+        InheretedStreamEvent(), BroadcastConfig(require_subscriber=False)
+    )
     await other.broadcast(StreamEvent())
 
     # wait for a received event, finishing the stream and

--- a/tests/core/asyncio/test_basics.py
+++ b/tests/core/asyncio/test_basics.py
@@ -8,6 +8,7 @@ from lahja import (
     AsyncioEndpoint,
     BaseEvent,
     BaseRequestResponseEvent,
+    BroadcastConfig,
     UnexpectedResponse,
 )
 
@@ -32,7 +33,9 @@ async def test_request_can_get_cancelled(endpoint_pair):
 
     item = Request("test")
     with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(alice.request(item), 0.0001)
+        await asyncio.wait_for(
+            alice.request(item, BroadcastConfig(require_subscriber=False)), 0.0001
+        )
     await asyncio.sleep(0.01)
     # Ensure the registration was cleaned up
     assert item._id not in alice._futures

--- a/tests/core/common/test_endpoint_broadcast.py
+++ b/tests/core/common/test_endpoint_broadcast.py
@@ -1,4 +1,5 @@
-from lahja import BaseEvent, ConnectionConfig
+from lahja import BaseEvent, BroadcastConfig, ConnectionConfig
+from lahja.exceptions import NoSubscribers
 from lahja.tools import drivers as d
 
 
@@ -31,6 +32,40 @@ def test_endpoint_broadcast_from_server_to_client(ipc_base_path, runner):
         d.run_endpoint("client"),
         d.connect_to_endpoints(server_config),
         d.wait_for(Event),
+    )
+
+    runner(server, client)
+
+
+def test_broadcast_without_listeners_throws(ipc_base_path, runner):
+    server_config = ConnectionConfig.from_name("server", base_path=ipc_base_path)
+    server_done, client_done = d.checkpoint("done")
+
+    server = d.driver(d.serve_endpoint(server_config), server_done)
+
+    client = d.driver(
+        d.run_endpoint("client"),
+        d.connect_to_endpoints(server_config),
+        d.wait_until_connected_to("server"),
+        d.throws(d.broadcast(Event()), NoSubscribers),
+        client_done,
+    )
+
+    runner(server, client)
+
+
+def test_broadcast_without_listeners_explicitly_allowed(ipc_base_path, runner):
+    server_config = ConnectionConfig.from_name("server", base_path=ipc_base_path)
+    server_done, client_done = d.checkpoint("done")
+
+    server = d.driver(d.serve_endpoint(server_config), server_done)
+
+    client = d.driver(
+        d.run_endpoint("client"),
+        d.connect_to_endpoints(server_config),
+        d.wait_until_connected_to("server"),
+        d.broadcast(Event(), BroadcastConfig(require_subscriber=False)),
+        client_done,
     )
 
     runner(server, client)

--- a/tests/core/common/test_endpoint_request_response.py
+++ b/tests/core/common/test_endpoint_request_response.py
@@ -1,6 +1,7 @@
 import multiprocessing
 
 from lahja import BaseEvent, BaseRequestResponseEvent, ConnectionConfig
+from lahja.exceptions import NoSubscribers
 from lahja.tools import drivers as d
 
 
@@ -33,3 +34,15 @@ def test_request_response(runner, ipc_base_path):
 
     runner(server, client)
     assert received.is_set()
+
+
+def test_request_without_subscriber_throws(runner, ipc_base_path):
+    server_config = ConnectionConfig.from_name("server", base_path=ipc_base_path)
+
+    server = d.driver(d.serve_endpoint(server_config))
+
+    client = d.driver(
+        d.run_endpoint("client"), d.throws(d.request(Request()), NoSubscribers)
+    )
+
+    runner(server, client)

--- a/tests/core/trio/test_trio_endpoint_subscribe.py
+++ b/tests/core/trio/test_trio_endpoint_subscribe.py
@@ -1,7 +1,7 @@
 import pytest
 import trio
 
-from lahja import BaseEvent
+from lahja import BaseEvent, BroadcastConfig
 
 
 class EventTest(BaseEvent):
@@ -27,8 +27,8 @@ async def test_trio_endpoint_subscribe(endpoint_pair):
     await bob.wait_until_endpoint_subscribed_to(alice.name, EventTest)
 
     await bob.broadcast(EventTest())
-    await bob.broadcast(EventUnexpected())
-    await bob.broadcast(EventInherited())
+    await bob.broadcast(EventUnexpected(), BroadcastConfig(require_subscriber=False))
+    await bob.broadcast(EventInherited(), BroadcastConfig(require_subscriber=False))
     await bob.broadcast(EventTest())
 
     # enough cycles to allow the alice to process the event
@@ -49,8 +49,8 @@ async def test_trio_endpoint_unsubscribe(endpoint_pair):
     await bob.wait_until_endpoint_subscribed_to(alice.name, EventTest)
 
     await bob.broadcast(EventTest())
-    await bob.broadcast(EventUnexpected())
-    await bob.broadcast(EventInherited())
+    await bob.broadcast(EventUnexpected(), BroadcastConfig(require_subscriber=False))
+    await bob.broadcast(EventInherited(), BroadcastConfig(require_subscriber=False))
     await bob.broadcast(EventTest())
 
     # enough cycles to allow the alice to process the event
@@ -58,10 +58,10 @@ async def test_trio_endpoint_unsubscribe(endpoint_pair):
 
     subscription.unsubscribe()
 
-    await bob.broadcast(EventTest())
-    await bob.broadcast(EventUnexpected())
-    await bob.broadcast(EventInherited())
-    await bob.broadcast(EventTest())
+    await bob.broadcast(EventTest(), BroadcastConfig(require_subscriber=False))
+    await bob.broadcast(EventUnexpected(), BroadcastConfig(require_subscriber=False))
+    await bob.broadcast(EventInherited(), BroadcastConfig(require_subscriber=False))
+    await bob.broadcast(EventTest(), BroadcastConfig(require_subscriber=False))
 
     # enough cycles to allow the alice to process the event
     await trio.sleep(0.05)


### PR DESCRIPTION
### What was wrong?

It is easy to end up in a scenario where important events are forgotten to get subscribed to. This can lead to fatal bugs such as [Trinity not propagating any transactions to its peers](https://github.com/ethereum/trinity/pull/1649)

### How was it fixed?

1. By default any broadcasted event as well as any send request will throw a `NoSubscriber` exception if there are no subscribers to said event/request at the time when the event/request is being made.

2. Events/Requests can still be fired if there are no subscribers but it needs to be made explicit via `BroadcastConfig(raise_if_no_subscribers=False)`. As an example, this can be useful for events that are meant for extensibility to be subscribed to conditionally based on the fact whether a specific plugin is installed or not.

#### Alternative designs

I thought about using the `wait_until_any_endpoint_subscribed_to` API to allow *waiting* for subscriptions to be made before the event is send out but this has drawbacks:

1. It wouldn't work for the synchronous `broadcast_nowait` API

2. It raises the question how long should be waited for subscriptions. This could be made configurable but it feels like a weaker API.

3. When an endpoint connects to a remote endpoint, it does already wait for the initial batch of subscriptions for the remote endpoint anyway

4. Even if a subscription would be expected to arrive late it would be easy enough for the developer to use the `wait_until_any_endpoint_subscribed_to` manually *once* before firing the event.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/lahja/blob/master/newsfragments/README.md)

[//]: # (See: https://lahja.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/lahja/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://assets3.thrillist.com/v1/image/2831871/size/tmg-article_tall;jpeg_quality=20.jpg)