### PR TITLE
Ensure asyncio Endpoint.stream implementation yields to event loop

### DIFF
--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -756,11 +756,13 @@ class AsyncioEndpoint(BaseEndpoint):
         try:
             for _ in iterations:
                 try:
-                    yield await queue.get()
+                    if queue.empty():
+                        yield await queue.get()
+                    else:
+                        yield queue.get_nowait()
+                        await asyncio.sleep(0)
                 except GeneratorExit:
                     break
-                else:
-                    await asyncio.sleep(0)
         finally:
             self._queues[event_type].remove(casted_queue)
             if not self._queues[event_type]:

--- a/lahja/asyncio/endpoint.py
+++ b/lahja/asyncio/endpoint.py
@@ -759,6 +759,8 @@ class AsyncioEndpoint(BaseEndpoint):
                     yield await queue.get()
                 except GeneratorExit:
                     break
+                else:
+                    await asyncio.sleep(0)
         finally:
             self._queues[event_type].remove(casted_queue)
             if not self._queues[event_type]:

--- a/newsfragments/179.bugfix.rst
+++ b/newsfragments/179.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure that the ``asyncio`` implementation releases control of the event loop on each iteration of the async iterator produced by `EndpointAPI.stream`


### PR DESCRIPTION
### What was wrong?

When using code like this, the async generator does not natively yield to the event loop:

```python
async for event in endpoint.stream(...):
    # do something
```

### How was it fixed?

Added a call to `await asyncio.sleep(0)` in the implementation so that it would not block other coroutines from executing.

#### Cute Animal Picture

![hawaiianchicken](https://user-images.githubusercontent.com/824194/89060006-6f1f7180-d31f-11ea-9983-b08707d56ea7.jpeg)
